### PR TITLE
Add --height option to set viewport height

### DIFF
--- a/include/wkhtmltox/imagesettings.hh
+++ b/include/wkhtmltox/imagesettings.hh
@@ -79,6 +79,9 @@ struct DLL_PUBLIC ImageGlobal {
 	//! Set the screen width
 	int screenWidth;
 
+	//! Set the screen height
+	int screenHeight;
+
 	//! Image Quality
 	int quality;
 

--- a/src/image/imagearguments.cc
+++ b/src/image/imagearguments.cc
@@ -32,6 +32,7 @@ ImageCommandLineParser::ImageCommandLineParser(wkhtmltopdf::settings::ImageGloba
 	extended(false);
 	qthack(false);
 	addarg("width",0,"Set screen width (default is 1024)", new IntSetter(s.screenWidth,"int"));
+  addarg("height",0,"Set screen height (default is calculated from page content)", new IntSetter(s.screenHeight, "int"));
 	// addarg("scale-w",0,"Set width for resizing", new IntSetter(s.scale.width,"int"));
 	// addarg("scale-h",0,"Set height for resizing", new IntSetter(s.scale.height,"int"));
 

--- a/src/lib/imageconverter.cc
+++ b/src/lib/imageconverter.cc
@@ -133,7 +133,10 @@ void ImageConverterPrivate::pagesLoaded(bool ok) {
 	}
 	loaderObject->page.mainFrame()->setScrollBarPolicy(Qt::Horizontal, Qt::ScrollBarAlwaysOff);
 	//Set the right height
-	loaderObject->page.setViewportSize(QSize(highWidth, frame->contentsSize().height()));
+  if(settings.screenHeight > 0)
+    loaderObject->page.setViewportSize(QSize(highWidth, settings.screenHeight));
+  else
+    loaderObject->page.setViewportSize(QSize(highWidth, frame->contentsSize().height()));
 
 	QPainter painter;
 	QSvgGenerator generator;

--- a/src/lib/imagesettings.cc
+++ b/src/lib/imagesettings.cc
@@ -45,6 +45,7 @@ template<>
 struct DLL_LOCAL ReflectImpl<ImageGlobal>: public ReflectClass {
 	ReflectImpl(ImageGlobal & c) {
 		WKHTMLTOPDF_REFLECT(screenWidth);
+		WKHTMLTOPDF_REFLECT(screenHeight);
 		WKHTMLTOPDF_REFLECT(quiet);
 		WKHTMLTOPDF_REFLECT(transparent);
 		WKHTMLTOPDF_REFLECT(useGraphics);
@@ -64,6 +65,7 @@ CropSettings::CropSettings():
 
 ImageGlobal::ImageGlobal():
 	screenWidth(1024),
+	screenHeight(0),
 	quiet(false),
 	transparent(false),
 	useGraphics(false),

--- a/src/lib/imagesettings.hh
+++ b/src/lib/imagesettings.hh
@@ -82,6 +82,9 @@ struct DLL_PUBLIC ImageGlobal {
 	//! Set the screen width
 	int screenWidth;
 
+	//! Set the screen height
+	int screenHeight;
+
 	//! Image Quality
 	int quality;
 


### PR DESCRIPTION
I've added a --height option to set viewport height.  I need it to emulate a particular screen geometry.  I anticipate others might need it to emulate iPhone, iPad, Android, etc. screen geometries.  Please let me know if there are any problems with the commit and I will fix them.  

We had a brief discussion of my issue via email, but the ultimately the solution we discussed (using crop-y) doesn't do what I needed, which is to emulate a browser window (or webview) of a specific width and height.

Thanks, and great project.

-Adam
