### PR TITLE
Fix to issue 149 to use baseUrl when resolving links

### DIFF
--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -393,7 +393,7 @@ void PdfConverterPrivate::findLinks(QWebFrame * frame, QVector<QPair<QWebElement
 		} else {
 			QUrl href(h);
 			if (href.isEmpty()) continue;
-			href=frame->url().resolved(href);
+			href=frame->baseUrl().resolved(href);
 			if (urlToPageObj.contains(href.toString(QUrl::RemoveFragment))) {
 				if (ulocal) {
 					PageObject * p = urlToPageObj[href.toString(QUrl::RemoveFragment)];


### PR DESCRIPTION
As per the patch I attached to the issue in google code, this uses the Qt frame baseURL to resolve relative urls when generating links for inclusion in the PDF.  This should fall back to the requested url if a base url is not explicitly specified.

Regards,
Trevor
