### PR TITLE
Fixed URI related issues

### DIFF
--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -412,8 +412,11 @@ void PdfConverterPrivate::findLinks(QWebFrame * frame, QVector<QPair<QWebElement
 						local.push_back( qMakePair(elm, href.toString()) );
 					}
 				}
-			} else if (uexternal)
-				external.push_back( qMakePair(elm, href.toString() ) );
+			} else if (uexternal) {
+				// pass the unresolved url to WebKit. WebKit will resolve it
+				// depending upon the type of url - filepath, web-uri etc.
+				external.push_back( qMakePair(elm, h) );
+			}
 		}
 	}
 }


### PR DESCRIPTION
(1) Relative urls - Link pointing to relative path now opens correctly
(2) URLs without http:// in front of it. e.g. "www.google.com" now opens correctly

Example:- the following content when converted to pdf will now generat correct "Open B" and "Google" links.

&lt;a href="b.html" &gt;Open B&lt;/a&gt;
&lt;a href="www.google.com" &gt;Google&lt;/a&gt;
