### PR TITLE
building static library on osx

### DIFF
--- a/scripts/build-osx-x86
+++ b/scripts/build-osx-x86
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+qmake wkhtmltopdf.pro -spec macx-g++
+
+make src/image/Makefile
+make src/pdf/Makefile
+make src/lib/Makefile
+
+for makefile in `find . -name Makefile`
+do
+  echo "update: $makefile"
+  tmp=make.$$
+  cat $makefile | sed -e 's/i386/x86_64/g' > $tmp
+  mv $tmp $makefile
+done
+
+cd src/lib && make staticlib
+cd -
+
+echo "build examples"
+tmp=make.$$
+cat examples/Makefile | sed -e 's/-L ..\/bin -lwkhtmltox/..\/bin\/libwkhtmltox.a -lstdc++ -framework QtWebkit -framework QtSvg -framework QtXmlPatterns -framework QtGui -framework QtCore -framework QtNetwork/g' > $tmp
+mv $tmp examples/Makefile
+cd examples && make
+cd -


### PR DESCRIPTION
I hope this helps others build static library on osx as for me it took quiet a bit of poking around to figure out what the right sequence of events was to first get qmake to run and then to get the right architecture flags for 10.6 and 10.7.

Using sed to replace the arch flag - I don't think this is ideal, but I didn't see any other way to do this with qmake....

My goal is to make it easy to build the static library so that it might be possible to include wkhtmltox as a dependency on embedded languages.
