### PR TITLE
Enhancement for Issue 810: Browser Cache Control

### DIFF
--- a/include/wkhtmltox/loadsettings.hh
+++ b/include/wkhtmltox/loadsettings.hh
@@ -118,6 +118,8 @@ struct DLL_PUBLIC LoadPage {
 	QString checkboxCheckedSvg;
 	QString radiobuttonSvg;
 	QString radiobuttonCheckedSvg;
+
+	QString cacheDir;
 };
 
 DLL_PUBLIC LoadPage::LoadErrorHandling strToLoadErrorHandling(const char * s, bool * ok=0);

--- a/src/lib/loadsettings.cc
+++ b/src/lib/loadsettings.cc
@@ -134,6 +134,7 @@ LoadGlobal::LoadGlobal():
 LoadPage::LoadPage():
 	jsdelay(200),
 	windowStatus(""),
+	cacheDir(""),
 	zoomFactor(1.0),
 	repeatCustomHeaders(false),
 	blockLocalFileAccess(false),

--- a/src/lib/loadsettings.hh
+++ b/src/lib/loadsettings.hh
@@ -121,6 +121,8 @@ struct DLL_PUBLIC LoadPage {
 	QString checkboxCheckedSvg;
 	QString radiobuttonSvg;
 	QString radiobuttonCheckedSvg;
+
+	QString cacheDir;
 };
 
 DLL_PUBLIC LoadPage::LoadErrorHandling strToLoadErrorHandling(const char * s, bool * ok=0);

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -28,6 +28,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QNetworkCookie>
+#include <QNetworkDiskCache>
 #include <QTimer>
 #include <QUuid>
 
@@ -45,7 +46,13 @@ namespace wkhtmltopdf {
 
 LoaderObject::LoaderObject(QWebPage & p): page(p), skip(false) {};
 
-MyNetworkAccessManager::MyNetworkAccessManager(const settings::LoadPage & s): settings(s) {}
+MyNetworkAccessManager::MyNetworkAccessManager(const settings::LoadPage & s): settings(s) {
+	if ( !s.cacheDir.isEmpty() ){
+		QNetworkDiskCache *cache = new QNetworkDiskCache(this);
+		cache->setCacheDirectory(s.cacheDir);
+		QNetworkAccessManager::setCache(cache);
+	}
+}
 
 void MyNetworkAccessManager::allow(QString path) {
 	QString x = QFileInfo(path).canonicalFilePath();

--- a/src/lib/reflect.cc
+++ b/src/lib/reflect.cc
@@ -80,6 +80,7 @@ ReflectImpl<LoadPage>::ReflectImpl(LoadPage & c) {
 	WKHTMLTOPDF_REFLECT(checkboxCheckedSvg);
 	WKHTMLTOPDF_REFLECT(radiobuttonSvg);
 	WKHTMLTOPDF_REFLECT(radiobuttonCheckedSvg);
+	WKHTMLTOPDF_REFLECT(cacheDir);
 }
 
 ReflectImpl<Web>::ReflectImpl(Web & c) {

--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -219,6 +219,8 @@ void CommandLineParserBase::addPageLoadArgs(LoadPage & s) {
 	addarg("enable-local-file-access", 0, "Allowed conversion of a local file to read in other local files.", new ConstSetter<bool>(s.blockLocalFileAccess, false));
 	addarg("allow", 0, "Allow the file or files from the specified folder to be loaded (repeatable)", new StringListSetter(s.allowed,"path"));
 
+	addarg("cache-dir", 0, "Web cache directory", new QStrSetter(s.cacheDir,"path"));
+
 	addarg("debug-javascript", 0,"Show javascript debugging output", new ConstSetter<bool>(s.debugJavascript, true));
 	addarg("no-debug-javascript", 0,"Do not show javascript debugging output", new ConstSetter<bool>(s.debugJavascript, false));
 #if QT_VERSION >= 0x040600


### PR DESCRIPTION
This patch adds a --cache-dir <path> option.

It creates a QNetworkDiskCache if the option is specified.

Deleting the directory is left to the user, as he might want to re-use the cache for a later invocation.
