### PR TITLE
Fix top/bottom margin when not using dynamic header/footer

### DIFF
--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -208,6 +208,10 @@ void PdfConverterPrivate::beginConvert() {
         if (settings.margin.bottom.first == -1) {
             settings.margin.bottom.first = 10;
         }
+        
+        // set static header/footer reserve heights
+        o.headerReserveHeight = settings.margin.top.first;
+        o.footerReserveHeight = settings.margin.bottom.first;
 
         pageLoader.load();
     }


### PR DESCRIPTION
Unfortunately 80cbcc5db95eb48127a2d1418653e8643ad74f46 to add auto calculation of header/footer nerfs the static top/bottom margins if we're using simple header/footer text or no headers/footers at all.

I believe this restores the previous behaviour in the simplest manner possible.
