### PR TITLE
Set static header/footer on first page object

### DIFF
--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -210,8 +210,8 @@ void PdfConverterPrivate::beginConvert() {
         }
         
         // set static header/footer reserve heights
-        o.headerReserveHeight = settings.margin.top.first;
-        o.footerReserveHeight = settings.margin.bottom.first;
+        objects[0].headerReserveHeight = settings.margin.top.first;
+        objects[0].footerReserveHeight = settings.margin.bottom.first;
 
         pageLoader.load();
     }


### PR DESCRIPTION
Sorry, I'm an idiot. The last pull request for this issue stupidly tried to set the margins on an out-of-scope page object. That's what I get for not checking what I've pushed to the repo is actually what I've just compiled!

In general it looks like header height and margin calculation could do with a bit of a tidy-up as it appears there has been a partial attempt at having different header heights/margins for each page object. I don't want to stick my oar in here though without fully understanding what is desired/expected so I've kept this simple.

Apologies for my incompetence!
