### PR TITLE
Add support for "Effective Url's" for resolving relative paths to CSS/JS/etc files

### DIFF
--- a/include/wkhtmltox/loadsettings.hh
+++ b/include/wkhtmltox/loadsettings.hh
@@ -65,7 +65,7 @@ struct DLL_PUBLIC LoadPage {
 		skip,
 		ignore
 	};
-
+	
 	//! Username used for http auth login
 	QString username;
 
@@ -122,6 +122,9 @@ struct DLL_PUBLIC LoadPage {
 
 	QString cacheDir;
 	static QList<QString> mediaFilesExtensions;
+	
+	//! URL that this page should be considered to live at (only for pages specified by html)
+	QString effectiveUrl;
 };
 
 DLL_PUBLIC LoadPage::LoadErrorHandling strToLoadErrorHandling(const char * s, bool * ok=0);

--- a/src/lib/loadsettings.hh
+++ b/src/lib/loadsettings.hh
@@ -125,6 +125,9 @@ struct DLL_PUBLIC LoadPage {
 
 	QString cacheDir;
 	static QList<QString> mediaFilesExtensions;
+	
+	//! URL that this page should be considered to live at (only for pages specified by html)
+	QString effectiveUrl;
 };
 
 DLL_PUBLIC LoadPage::LoadErrorHandling strToLoadErrorHandling(const char * s, bool * ok=0);

--- a/src/lib/multipageloader_p.hh
+++ b/src/lib/multipageloader_p.hh
@@ -70,18 +70,33 @@ public slots:
 	bool shouldInterruptJavaScript();
 };
 
+struct ResourceType
+{
+	enum _
+	{
+		Url,
+		String
+	};
+};
+
 class DLL_LOCAL ResourceObject: public QObject {
 	Q_OBJECT
 private:
 	MyNetworkAccessManager networkAccessManager;
 	QUrl url;
+	QString data;
 	int loginTry;
 	int progress;
 	bool finished;
 	bool signalPrint;
 	MultiPageLoaderPrivate & multiPageLoader;
+	ResourceType::_ type;
+	void sharedUrlSetup(MultiPageLoaderPrivate & mpl, const QUrl & u, const settings::LoadPage & s);
+	void loadForUrl();
+	void loadForString();
 public:
 	ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, const settings::LoadPage & s);
+	ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & fileUrl, const QString & dataIn, const settings::LoadPage & s);
 	MyQWebPage webPage;
 	LoaderObject lo;
 	int httpErrorCode;

--- a/src/lib/reflect.cc
+++ b/src/lib/reflect.cc
@@ -60,6 +60,7 @@ ReflectImpl<LoadGlobal>::ReflectImpl(LoadGlobal & c) {
 }
 
 ReflectImpl<LoadPage>::ReflectImpl(LoadPage & c) {
+	WKHTMLTOPDF_REFLECT(effectiveUrl);
 	WKHTMLTOPDF_REFLECT(username);
 	WKHTMLTOPDF_REFLECT(password);
 	WKHTMLTOPDF_REFLECT(jsdelay);

--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -199,6 +199,9 @@ void CommandLineParserBase::addWebArgs(Web & s) {
 void CommandLineParserBase::addPageLoadArgs(LoadPage & s) {
 	extended(true);
 	qthack(false);
+	
+	addarg("effective-url", 0, "Effective URL of data", new QStrSetter(s.effectiveUrl, "effectiveUrl"));
+	
 	addarg("proxy",'p',"Use a proxy", new ProxySetter(s.proxy, "proxy"));
 	addarg("username",0,"HTTP Authentication username", new QStrSetter(s.username, "username"));
 	addarg("password",0,"HTTP Authentication password", new QStrSetter(s.password, "password"));


### PR DESCRIPTION
At the moment, when a HTML string is supplied directly to libwkhtmltopdf,
be that via an API call or via the - command line option to wkhtmltopdf,
relative URL's contained in the HTML are not resolved.

This change adds a field onto LoadSettings, effectiveUrl, that allows the
user to specify a URL, relative to which CSS/JS/etc link in the page will
be resolved. This is achieved by using the call
webPage.mainFrame()->setHtml() instead of ->load(), and supplying the
second argument as this effectiveUrl parameter passed down into
ResourceObject::load().
