### PR TITLE
Added qtwebkit patches for static and windows compilation

### DIFF
--- a/qtwebkit-nodll.diff
+++ b/qtwebkit-nodll.diff
@@ -1,0 +1,14 @@
+diff --git a/src/3rdparty/webkit/Source/WebCore/WebCore.pro b/src/3rdparty/webkit/Source/WebCore/WebCore.pro
+index ceceee8..55b1211 100644
+--- a/src/3rdparty/webkit/Source/WebCore/WebCore.pro
++++ b/src/3rdparty/webkit/Source/WebCore/WebCore.pro
+@@ -16,7 +16,8 @@ CONFIG += staticlib
+ DESTDIR = $$WEBCORE_DESTDIR
+ 
+ DEFINES += BUILDING_WEBKIT
+-DEFINES += QT_MAKEDLL
++#DEFINES += QT_MAKEDLL
++DEFINES += QT_NODLL
+ 
+ contains(DEFINES, WTF_USE_QT_MOBILE_THEME=1) {
+     DEFINES += ENABLE_NO_LISTBOX_RENDERING=1

--- a/qtwebkit-static.diff
+++ b/qtwebkit-static.diff
@@ -1,0 +1,85 @@
+adapted from https://github.com/ariya/phantomjs/commit/31157fbb98a9765c0043847a3a41359838aad0d0
+diff --git a/src/3rdparty/webkit/Source/WebKit.pro b/src/3rdparty/webkit/Source/WebKit.pro
+index 9be0f4a..abbccf7 100644
+--- a/src/3rdparty/webkit/Source/WebKit.pro
++++ b/src/3rdparty/webkit/Source/WebKit.pro
+@@ -3,14 +3,8 @@ CONFIG += ordered
+ 
+ include(WebKit.pri)
+ 
+-!v8 {
+-    exists($$PWD/JavaScriptCore/JavaScriptCore.pro): SUBDIRS += JavaScriptCore/JavaScriptCore.pro
+-    exists($$PWD/JavaScriptCore/jsc.pro): SUBDIRS += JavaScriptCore/jsc.pro
+-}
+-
+ webkit2:exists($$PWD/WebKit2/WebKit2.pro): SUBDIRS += WebKit2/WebKit2.pro
+ 
+-SUBDIRS += WebCore
+ SUBDIRS += WebKit/qt/QtWebKit.pro
+ 
+ webkit2 {
+diff --git a/src/3rdparty/webkit/Source/WebKit/qt/QtWebKit.pro b/src/3rdparty/webkit/Source/WebKit/qt/QtWebKit.pro
+index 4161832..7e0b0d2 100644
+--- a/src/3rdparty/webkit/Source/WebKit/qt/QtWebKit.pro
++++ b/src/3rdparty/webkit/Source/WebKit/qt/QtWebKit.pro
+@@ -2,7 +2,6 @@
+ CONFIG += building-libs
+ CONFIG += depend_includepath
+ 
+-TARGET = QtWebKit
+ TEMPLATE = lib
+ 
+ DEFINES += BUILDING_WEBKIT
+@@ -15,23 +14,45 @@ else: CONFIG_DIR = release
+ 
+ SOURCE_DIR = $$replace(PWD, /WebKit/qt, "")
+ 
+-include($$PWD/Api/headers.pri)
+ include($$SOURCE_DIR/WebKit.pri)
+-include($$SOURCE_DIR/JavaScriptCore/JavaScriptCore.pri)
++
++include($$SOURCE_DIR/JavaScriptCore/JavaScriptCore.pro)
++
++for(item, SOURCES):JAVASCRIPT_CORE_SOURCES += ../../JavaScriptCore/$$item
++
++unset(SOURCES)
++
++include($$SOURCE_DIR/WebCore/WebCore.pro)
++
++for(item, SOURCES): {
++    path = $$split(item, '/')
++
++    contains(path, sqlite3.c) {
++        WEB_CORE_SOURCES += $$item
++    }
++
++    !contains(path, sqlite3.c) {
++        WEB_CORE_SOURCES += ../../WebCore/$$item
++    }
++}
++for(item, HEADERS):WEB_CORE_HEADERS += ../../WebCore/$$item
++
++SOURCES = $$JAVASCRIPT_CORE_SOURCES $$WEB_CORE_SOURCES
++HEADERS = $$WEB_CORE_HEADERS
++
++include($$PWD/Api/headers.pri)
++
+ webkit2 {
+     include($$SOURCE_DIR/WebKit2/WebKit2.pri)
+     include($$SOURCE_DIR/WebKit2/WebKit2API.pri)
+ }
+-include($$SOURCE_DIR/WebCore/WebCore.pri)
+ 
+-!v8:prependJavaScriptCoreLib(../../JavaScriptCore)
+-prependWebCoreLib(../../WebCore)
+-webkit2:prependWebKit2Lib(../../WebKit2)
++TARGET = QtWebKit
+ 
+ # This is needed for syncqt when it parses the dependencies on module's main pro file so
+ # the generated includes are containing the dependencies.
+ # It used to be in WebCore.pro but now that this is the main pro file it has to be here.
+-QT += network
++QT += network gui
+ 
+ isEmpty(OUTPUT_DIR): OUTPUT_DIR = ../..
+ 

--- a/qtwebkit-time_t.diff
+++ b/qtwebkit-time_t.diff
@@ -1,0 +1,39 @@
+diff --git a/src/3rdparty/webkit/Source/WebCore/loader/icon/IconRecord.h b/src/3rdparty/webkit/Source/WebCore/loader/icon/IconRecord.h
+index 50ef7f7..67e7b82 100644
+--- a/src/3rdparty/webkit/Source/WebCore/loader/icon/IconRecord.h
++++ b/src/3rdparty/webkit/Source/WebCore/loader/icon/IconRecord.h
+@@ -38,7 +38,7 @@
+ #include <wtf/OwnPtr.h>
+ #include <wtf/text/StringHash.h>
+ 
+-#if OS(SOLARIS)
++#if OS(SOLARIS) || OS(WINDOWS)
+ #include <sys/types.h> // For time_t structure.
+ #endif
+ 
+diff --git a/src/3rdparty/webkit/Source/WebCore/page/Page.h b/src/3rdparty/webkit/Source/WebCore/page/Page.h
+index bdea870..68c9b76 100644
+--- a/src/3rdparty/webkit/Source/WebCore/page/Page.h
++++ b/src/3rdparty/webkit/Source/WebCore/page/Page.h
+@@ -29,7 +29,7 @@
+ #include <wtf/HashSet.h>
+ #include <wtf/Noncopyable.h>
+ 
+-#if OS(SOLARIS)
++#if OS(SOLARIS) || OS(WINDOWS)
+ #include <sys/time.h> // For time_t structure.
+ #endif
+ 
+diff --git a/src/3rdparty/webkit/Source/WebCore/platform/network/ResourceResponseBase.h b/src/3rdparty/webkit/Source/WebCore/platform/network/ResourceResponseBase.h
+index 250411c..9d9344e 100644
+--- a/src/3rdparty/webkit/Source/WebCore/platform/network/ResourceResponseBase.h
++++ b/src/3rdparty/webkit/Source/WebCore/platform/network/ResourceResponseBase.h
+@@ -35,7 +35,7 @@
+ #include <wtf/PassOwnPtr.h>
+ #include <wtf/RefPtr.h>
+ 
+-#if OS(SOLARIS)
++#if OS(SOLARIS) || OS(WINDOWS)
+ #include <sys/time.h> // For time_t structure.
+ #endif
+ 

--- a/scripts/static-build.sh
+++ b/scripts/static-build.sh
@@ -132,6 +132,9 @@ function setup_build() {
     if ! [ -z "$VERSION" ] ; then
 		git checkout wkhtmltopdf-$VERSION || exit 1
     fi
+    patch -p1 < ${BASE}/qtwebkit-static.diff
+    patch -p1 < ${BASE}/qtwebkit-time_t.diff
+    patch -p1 < ${BASE}/qtwebkit-nodll.diff
     touch conf
     cat ${BASE}/static_qt_conf_base ${BASE}/static_qt_conf_${1} | sed -re 's/#.*//' | sed -re '/^[ \t]*$/d' | sort -u > conf_new
     cd ..
@@ -265,6 +268,10 @@ EOF
 
     cd ..
     setup_build win
+    if [ ! -f windows/perl.exe ]; then
+        echo 'int main(){return 0;}' > windows/perl.c
+        wine 'c:\mingw\bin\gcc.exe' -o 'c:\windows\perl.exe' 'c:\windows\perl.c'
+    fi
 
     unset CPLUS_INCLUDE_PATH
     unset C_INCLUDE_PATH


### PR DESCRIPTION
qtwebkit-static patch adapted from https://github.com/ariya/phantomjs/commit/31157fbb98a9765c0043847a3a41359838aad0d0 by jonleighton

I have tried with your repository, it didn't worked because it was missing lwebcore and ljscore libraries.
This patch fixes those missing libraries.
