### PR TITLE
Being explicit about xrender support

### DIFF
--- a/static_qt_conf_base
+++ b/static_qt_conf_base
@@ -29,6 +29,7 @@
 -no-phonon
 -no-phonon-backend
 -webkit
+-xrender
 -no-scripttools
 -no-mmx
 -no-3dnow


### PR DESCRIPTION
Xrender support is needed to build the webkit module.

The default value for xrender is auto, so if there is no xrender it silently continues to build.
QT is build fine, but wkhtmltopdf fails because of no webkit support.

By being explicit we make sure webkit will be installed. If can't be installed it will error out and not build QT.
