### PR TITLE
Fix Issue #1277: Avoid premature deletion of ResourceObject (which my be still being referenced by some other object handling some signal) by using deleteLater instead of delete.

### DIFF
--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -480,7 +480,7 @@ void MultiPageLoaderPrivate::load() {
 
 void MultiPageLoaderPrivate::clearResources() {
 	for (int i=0; i < resources.size(); ++i)
-		delete resources[i];
+		resources[i]->deleteLater();
 	resources.clear();
 	tempIn.remove();
 }


### PR DESCRIPTION
See: https://code.google.com/p/wkhtmltopdf/issues/detail?id=1277&thanks=1277&ts=1384369930
