### PR TITLE
${EnvVarUpdate} $0 "PATH" "A" is supposed to append but it's overwriting...

### DIFF
--- a/wkhtmltopdf.nsi.m4
+++ b/wkhtmltopdf.nsi.m4
@@ -47,7 +47,8 @@ Section "Wkhtmltoimage" image
 SectionEnd
 
 Section /o "Modify PATH" mpath
-  ${EnvVarUpdate} $0 "PATH" "A" "HKLM" "$INSTDIR" 
+	;Commented out because it's overwriting and not appending
+  ;${EnvVarUpdate} $0 "PATH" "A" "HKLM" "$INSTDIR" 
 SectionEnd
 
 LangString DESC_pdf   ${LANG_ENGLISH} "Install wkhtmltopdf."


### PR DESCRIPTION
... so for now it's gone and you have to add the executable to your path manually (rather than have it wipe out your entire path, rending your system useless for just about everything including WKHTMLTOPDF).

Signed-off-by: unknown michael@RAINABBA4.compteknet.local
