### PR TITLE
fix crash when --header-html is specified

### DIFF
--- a/src/lib/pdfconverter_p.hh
+++ b/src/lib/pdfconverter_p.hh
@@ -169,7 +169,7 @@ private:
 	QWebPage * currentHeader;
 	QWebPage * currentFooter;
     qreal calculateHeaderHeight(PageObject & object, QWebPage & header);
-    QPrinter * createPrinter();
+    QPrinter * createPrinter(const QString & tempFile);
 
 	void handleTocPage(PageObject & obj);
 	void preprocessPage(PageObject & obj);


### PR DESCRIPTION
This was introduced in 80cbcc5, where the createPrinter() method created the printer with an empty filename as output filename is initialised in pagesLoaded() but it gets called prior to that. This would result in a crash after the errors such as
`QWin32PrintEngine::initialize: OpenPrinter failed`
Additionally, QPainter::begin() was not called for the printer resulting in additional errors being printed.
