### PR TITLE
ignore untracked files generated during the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ static-build/
 doc/
 man1/
 Makefile
+Makefile.*
+*_resource.rc
 gitcontrol.bat
 gitcmd.lnk


### PR DESCRIPTION
Ignore the following untracked files which are generated during the MSVC build:

```
# HEAD detached at 924bcb7
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#       src/image/Makefile.Debug
#       src/image/Makefile.Release
#       src/image/wkhtmltoimage_resource.rc
#       src/lib/Makefile.Debug
#       src/lib/Makefile.Release
#       src/lib/wkhtmltox_resource.rc
#       src/pdf/Makefile.Debug
#       src/pdf/Makefile.Release
#       src/pdf/wkhtmltopdf_resource.rc
```
