### PR TITLE
Issue #1536 - Optional QPrinter::NativeFormat

### DIFF
--- a/include/wkhtmltox/pdfsettings.hh
+++ b/include/wkhtmltox/pdfsettings.hh
@@ -141,6 +141,8 @@ struct DLL_PUBLIC PdfGlobal {
 	int imageDPI;
 	int imageQuality;
 
+	bool useNativeFormatPrinter; // use QPrinter::NativeFormat on Mac OS X?
+
 	LoadGlobal load;
 
 	QString get(const char * name);

--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -127,6 +127,7 @@
  * - \b outputFormat The format of the output document, must be ether "", "pdf" or "ps".
  * - \b imageDPI The maximal DPI to use for images in the pdf document.
  * - \b imageQuality The jpeg compression factor to use when producing the pdf document, e.g. "92".
+ * - \b useNativeFormatPrinter Should we use QPrinter::NativeFormat when creating the pdf file? Must be either "true" or "false". (Mac OS X only).
  * - \b load.cookieJar Path of file used to load and store cookies.
  *
  * \section pagePdfObject Pdf object settings

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -265,7 +265,7 @@ QPrinter * PdfConverterPrivate::createPrinter(const QString & tempFile) {
     printer->setOutputFormat(
         (settings.outputFormat == "ps" || (settings.outputFormat == "" && settings.out.endsWith(".ps", Qt::CaseInsensitive)))?
 #ifdef Q_WS_MACX
-        QPrinter::PostScriptFormat : QPrinter::NativeFormat
+        QPrinter::PostScriptFormat : settings.useNativeFormatPrinter ? QPrinter::NativeFormat : QPrinter::PdfFormat
 #else
         QPrinter::PostScriptFormat : QPrinter::PdfFormat
 #endif
@@ -350,7 +350,7 @@ void PdfConverterPrivate::pagesLoaded(bool ok) {
 	printer->setOutputFormat(
 		(settings.outputFormat == "ps" || (settings.outputFormat == "" && settings.out.endsWith(".ps", Qt::CaseInsensitive)))?
 #ifdef Q_WS_MACX
-		QPrinter::PostScriptFormat : QPrinter::NativeFormat
+		QPrinter::PostScriptFormat : settings.useNativeFormatPrinter ? QPrinter::NativeFormat : QPrinter::PdfFormat
 #else
 		QPrinter::PostScriptFormat : QPrinter::PdfFormat
 #endif

--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -126,11 +126,12 @@ struct DLL_LOCAL ReflectImpl<PdfGlobal>: public ReflectClass {
 		WKHTMLTOPDF_REFLECT(out);
 		WKHTMLTOPDF_REFLECT(documentTitle);
 		WKHTMLTOPDF_REFLECT(useCompression);
-		WKHTMLTOPDF_REFLECT(margin);
-		WKHTMLTOPDF_REFLECT(outputFormat);
-		WKHTMLTOPDF_REFLECT(imageDPI);
-		WKHTMLTOPDF_REFLECT(imageQuality);
-		WKHTMLTOPDF_REFLECT(load);
+        WKHTMLTOPDF_REFLECT(margin);
+        WKHTMLTOPDF_REFLECT(outputFormat);
+        WKHTMLTOPDF_REFLECT(imageDPI);
+        WKHTMLTOPDF_REFLECT(imageQuality);
+        WKHTMLTOPDF_REFLECT(useNativeFormatPrinter);
+        WKHTMLTOPDF_REFLECT(load);
 	}
 };
 
@@ -386,9 +387,10 @@ PdfGlobal::PdfGlobal():
 	out(""),
 	documentTitle(""),
 	useCompression(true),
-	imageDPI(600),
-	imageQuality(94),
-	viewportSize(""){};
+    imageDPI(600),
+    imageQuality(94),
+    useNativeFormatPrinter(false),
+    viewportSize(""){};
 
 TableOfContent::TableOfContent():
 	useDottedLines(true),

--- a/src/lib/pdfsettings.hh
+++ b/src/lib/pdfsettings.hh
@@ -144,6 +144,8 @@ struct DLL_PUBLIC PdfGlobal {
 	int imageDPI;
 	int imageQuality;
 
+	bool useNativeFormatPrinter; // use QPrinter::NativeFormat on Mac OS X?
+
 	LoadGlobal load;
 
 	QString get(const char * name);

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -215,7 +215,11 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
 	addarg("image-quality", 0, "When jpeg compressing images use this quality", new IntSetter(s.imageQuality,"integer"));
 	addarg("image-dpi", 0, "When embedding images scale them down to this dpi", new IntSetter(s.imageDPI, "integer"));
 
-	addarg("no-pdf-compression", 0 , "Do not use lossless compression on pdf objects", new ConstSetter<bool>(s.useCompression,false));
+    addarg("no-pdf-compression", 0 , "Do not use lossless compression on pdf objects", new ConstSetter<bool>(s.useCompression,false));
+
+#ifdef Q_WS_MACX
+	addarg("native-format-printer", 0 , "Use the native Mac OS X PDF printer to produce a PDF with selectable text. Note: This printer breaks some advanced features of wkhtmltopdf. Use at your own risk.", new ConstSetter<bool>(s.useNativeFormatPrinter,true));
+#endif
 
  #ifdef Q_WS_X11
  	addarg("use-xserver",0,"Use the X server (some plugins and other stuff might not work without X11)", new ConstSetter<bool>(s.useGraphics,true));


### PR DESCRIPTION
Implemented --native-format-printer option on OS X to allow the user to select the QPrinter::NativeFormat printer (disabled by default)
