### PR TITLE
Use env var SUDO_USER when logname cannot determine username

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -404,7 +404,9 @@ def check_setup_schroot(config):
     check_running_on_debian()
     login = get_output('logname')
     if not login:
-        error('Unable to determine the login for which schroot access is to be given.')
+        login = get_output('echo','$SUDO_USER')
+        if not login:
+            error('Unable to determine the login for which schroot access is to be given.')
 
     if login == 'root':
         error('Please run via sudo to determine login for which schroot access is to be given.')


### PR DESCRIPTION
When compiling from openvz, if you've entered your container by doing a `vzctl enter CTID` there is no logname defined, so `logname` won't work, but $SUDO_USER can be used.

I guess that this should fix compiling from any non-login shell.
