### PR TITLE
add cmd line arg --bypass-list

### DIFF
--- a/include/wkhtmltox/loadsettings.hh
+++ b/include/wkhtmltox/loadsettings.hh
@@ -38,6 +38,8 @@ struct DLL_PUBLIC Proxy {
 	QString user;
 	//! Password for the said proxy or NULL
 	QString password;
+	//! bypass address list
+	QString bypassList;
 };
 
 struct DLL_PUBLIC PostItem {

--- a/src/lib/loadsettings.cc
+++ b/src/lib/loadsettings.cc
@@ -130,7 +130,8 @@ Proxy::Proxy():
 	port(-1),
 	host(),
 	user(),
-	password() {}
+	password(),
+	bypassList() {}
 
 LoadGlobal::LoadGlobal():
 	cookieJar("") {}

--- a/src/lib/loadsettings.hh
+++ b/src/lib/loadsettings.hh
@@ -41,6 +41,8 @@ struct DLL_PUBLIC Proxy {
 	QString user;
 	//! Password for the said proxy or NULL
 	QString password;
+	//! bypass address list
+	QString bypassList;
 };
 
 struct DLL_PUBLIC PostItem {

--- a/src/lib/multipageloader_p.hh
+++ b/src/lib/multipageloader_p.hh
@@ -136,6 +136,18 @@ public slots:
 	void loadDone();
 };
 
+class DLL_LOCAL MyNetworkProxyFactory: public QNetworkProxyFactory {
+
+private:
+	const settings::LoadPage settings;
+	QNetworkProxy proxy;
+	
+public:
+	MyNetworkProxyFactory(const settings::LoadPage & s);
+	virtual QList<QNetworkProxy> queryProxy(const QNetworkProxyQuery & query = QNetworkProxyQuery());
+};
+
+
 }
 #include "dllend.inc"
 #endif //__MULTIPAGELOADER_P_HH__

--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -205,6 +205,9 @@ void CommandLineParserBase::addPageLoadArgs(LoadPage & s) {
 	addarg("proxy",'p',"Use a proxy", new ProxySetter(s.proxy, "proxy"));
 	addarg("username",0,"HTTP Authentication username", new QStrSetter(s.username, "username"));
 	addarg("password",0,"HTTP Authentication password", new QStrSetter(s.password, "password"));
+	
+	addarg("bypass-proxy",0,"bypass proxy for given addresses", new QStrSetter(s.proxy.bypassList, "address list"));
+	
 	addarg("load-error-handling", 0, "Specify how to handle pages that fail to load: abort, ignore or skip", new LoadErrorHandlingSetting(s.loadErrorHandling, "handler"));
 	addarg("load-media-error-handling", 0, "Specify how to handle media files that fail to load: abort, ignore or skip", new LoadErrorHandlingSetting(s.mediaLoadErrorHandling, "handler"));
 	addarg("custom-header",0,"Set an additional HTTP header (repeatable)", new MapSetter<>(s.customHeaders, "name", "value"));


### PR DESCRIPTION
I tried to add a new cmd line arg to wkhtmltopdf.exe called --bypass-list
You can give a comma separated list of addresses for which the given proxy should be bypassed.

Unfortunately wkhtmltopdf.exe crashes at runtime when called like this:
wkhtmltopdf.exe -p "myproxy:8081" --bypass-proxy "myspecialhost" "http://mywebpage/action?show" "screenshot.pdf"

Could anyone help in this matter!?
