### PR TITLE
Improve docs for --cookie option

### DIFF
--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -215,7 +215,7 @@ void CommandLineParserBase::addPageLoadArgs(LoadPage & s) {
 	addarg("window-status",0,"Wait until window.status is equal to this string before rendering page", new QStrSetter(s.windowStatus, "windowStatus"));
 
 	addarg("zoom",0,"Use this zoom factor", new FloatSetter(s.zoomFactor,"float",1.0));
-	addarg("cookie",0,"Set an additional cookie (repeatable)", new MapSetter<>(s.cookies, "name", "value"));
+	addarg("cookie",0,"Set an additional cookie (repeatable), value should be url encoded.", new MapSetter<>(s.cookies, "name", "value"));
 	addarg("post", 0, "Add an additional post field (repeatable)", new MapSetter<PostItemCreator<false> >(s.post, "name", "value"));
 	addarg("post-file", 0, "Post an additional file (repeatable)", new MapSetter<PostItemCreator<true> >(s.post, "name", "path"));
 


### PR DESCRIPTION
Thought this would be helpful in the docs, as we've been scratching our heads about seemingly "random" `Authentication Failures` when we used this option.
