### PR TITLE
Fix unicode URLs, added ISO date template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v0.12.2 (unreleased)
 * **#1676**: set page margins correctly via computed header/footer heights for multiple URLs
 * **#1758**: fix corrupt image when output is specified as "-" in wkhtmltoimage on Windows
 * **#1722**: **[qt]** fix broken hyphenation with soft-hyphens
+* **#1769**: fixed unicode URLs in links
 * **#1772**: added variable 'isodate' for substitution in headers/footers
 * **#1808**: fix [sitepage] and [sitepages] not working without HTML headers/footers
 * **#1825**: fix handling of non-ASCII characters in command-line arguments

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -559,9 +559,10 @@ void PdfConverterPrivate::findLinks(QWebFrame * frame, QVector<QPair<QWebElement
 			QUrl href(h);
 			if (href.isEmpty()) continue;
 			href=frame->baseUrl().resolved(href);
-			if (urlToPageObj.contains(href.toString(QUrl::RemoveFragment))) {
+			QString key = QUrl::fromPercentEncoding(href.toString(QUrl::RemoveFragment).toLocal8Bit());
+			if (urlToPageObj.contains(key)) {
 				if (ulocal) {
-					PageObject * p = urlToPageObj[href.toString(QUrl::RemoveFragment)];
+					PageObject * p = urlToPageObj[key];
 					QWebElement e;
 					if (!href.hasFragment())
 						e = p->page->mainFrame()->findFirstElement("body");
@@ -757,7 +758,7 @@ void PdfConverterPrivate::tocLoaded(bool ok) {
 		for (int d=0; d < objects.size(); ++d) {
 			if (!objects[d].loaderObject || objects[d].loaderObject->skip) continue;
 			if (objects[d].settings.isTableOfContent) continue;
-			urlToPageObj[ objects[d].page->mainFrame()->url().toString(QUrl::RemoveFragment) ] = &objects[d];
+			urlToPageObj[ QUrl::fromPercentEncoding(objects[d].page->mainFrame()->url().toString(QUrl::RemoveFragment).toLocal8Bit()) ] = &objects[d];
 		}
 
 		for (int d=0; d < objects.size(); ++d) {


### PR DESCRIPTION
Store in hashmap strings parsed from percent-encoded unicode URLs.
Added internationalized 'isodate' template besides of locale-dependent date.

We use wkhtmltopdf in cross-language web project with cyrillic and english urls. This patch fixes behaviour of wkhtmltopdf with percent-encoded urls. They are gathered from body as unicode strings but are read from argument list as percent-encoded strings.

Another portion of patch added a template 'isodate' because webserver system locale where wkhtmltopdf is launched is not always a good choose.
