### PR TITLE
Added ISO date template

### DIFF
--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -584,6 +584,7 @@ void PdfConverterPrivate::fillParms(QHash<QString, QString> & parms, int page, c
 	QDateTime t(QDateTime::currentDateTime());
 	parms["time"] = t.time().toString(Qt::SystemLocaleShortDate);
 	parms["date"] = t.date().toString(Qt::SystemLocaleShortDate);
+	parms["isodate"] = t.date().toString(Qt::ISODate);
 }
 
 


### PR DESCRIPTION
Added internationalized 'isodate' template besides of locale-dependent date 'date'.

Server system locale where wkhtmltopdf is launched is not always a good default choose.
