### PR TITLE
Remove the need for xz as a prerequisite for builds on OS X.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -104,12 +104,11 @@ OS X
 ----
 
 Building is supported only on OS X 10.6 or newer. You will need to have the
-the latest Xcode for your OS X version and also install
-[xz 5.0.5](http://downloads.sourceforge.net/project/macpkg/XZ/5.0.5/XZ.pkg).
-Additionally, you will need the command `sudo gem install fpm --no-ri --no-rdoc`
-in the terminal to install [fpm](https://github.com/jordansissel/fpm), which is
-used for building the package. Note that if you are using OS X 10.6, you will
-additionally need to install [git 1.8.4.2](https://git-osx-installer.googlecode.com/files/git-1.8.4.2-intel-universal-snow-leopard.dmg)
+latest Xcode for your OS X version. Additionally, you will need the command
+`sudo gem install fpm --no-ri --no-rdoc` in the terminal to install
+[fpm](https://github.com/jordansissel/fpm), which is used for building the package.
+Note that if you are using OS X 10.6, you will additionally need to install
+[git 1.8.4.2](https://git-osx-installer.googlecode.com/files/git-1.8.4.2-intel-universal-snow-leopard.dmg)
 and [Python 2.7.6](https://www.python.org/ftp/python/2.7.6/python-2.7.6-macosx10.6.dmg)
 (you may need to run the `Update Shell Profile.command` in `/Applications/Python 2.7`
 to make it the default Python in the shell).


### PR DESCRIPTION
On OS X the previous version of the build script packs a locally installed `xz` into the installation package and unpacks it during installation, if `xz` isn't available on the target machine. This can lead to problems if on the build machine `xz` was installed by a package manager like Homebrew (packing symlinks instead of the real binary).

The modification creates `xz` during the build and packs it into the installation package. `xz` is now longer needed for the build.
