### PR TITLE
"setHtml" feature, header/footer from pipes and fixed all compiler warnings

### DIFF
--- a/include/wkhtmltox/pdfsettings.hh
+++ b/include/wkhtmltox/pdfsettings.hh
@@ -156,6 +156,8 @@ struct DLL_PUBLIC HeaderFooter {
 	bool line;
 	//! Url of the document the html document that should be used as a header/footer
 	QString htmlUrl;
+	//! Source of the document the html document that should be used as a header/footer
+	QString htmlSource;
 	//! Spacing
 	float spacing;
 };

--- a/src/lib/imagesettings.cc
+++ b/src/lib/imagesettings.cc
@@ -39,10 +39,10 @@ struct DLL_LOCAL ReflectImpl<CropSettings>: public ReflectClass {
 template<>
 struct DLL_LOCAL ReflectImpl<ImageGlobal>: public ReflectClass {
 	ReflectImpl(ImageGlobal & c) {
-		WKHTMLTOPDF_REFLECT(screenWidth);
-		WKHTMLTOPDF_REFLECT(screenHeight);
 		WKHTMLTOPDF_REFLECT(quiet);
 		WKHTMLTOPDF_REFLECT(transparent);
+		WKHTMLTOPDF_REFLECT(screenWidth);
+		WKHTMLTOPDF_REFLECT(screenHeight);
 		WKHTMLTOPDF_REFLECT(useGraphics);
 		WKHTMLTOPDF_REFLECT(in);
 		WKHTMLTOPDF_REFLECT(out);
@@ -60,14 +60,14 @@ CropSettings::CropSettings():
 	height(-1) {}
 
 ImageGlobal::ImageGlobal():
-	screenWidth(1024),
-	screenHeight(0),
 	quiet(false),
 	transparent(false),
 	useGraphics(false),
 	in(""),
 	out(""),
 	fmt(""),
+	screenWidth(1024),
+	screenHeight(0),
 	quality(94),
 	smartWidth(true) {}
 

--- a/src/lib/loadsettings.cc
+++ b/src/lib/loadsettings.cc
@@ -138,14 +138,14 @@ LoadGlobal::LoadGlobal():
 LoadPage::LoadPage():
 	jsdelay(200),
 	windowStatus(""),
-	cacheDir(""),
 	zoomFactor(1.0),
 	repeatCustomHeaders(false),
 	blockLocalFileAccess(false),
 	stopSlowScripts(true),
 	debugJavascript(false),
 	loadErrorHandling(abort),
-	mediaLoadErrorHandling(ignore) {};
+	mediaLoadErrorHandling(ignore),
+	cacheDir("") {};
 
 }
 }

--- a/src/lib/multipageloader.hh
+++ b/src/lib/multipageloader.hh
@@ -51,8 +51,9 @@ public:
 	MultiPageLoader(settings::LoadGlobal & s);
 	~MultiPageLoader();
 	LoaderObject * addResource(const QString & url, const settings::LoadPage & settings, const QString * data=NULL);
+	LoaderObject * addResource(const QUrl & url, const settings::LoadPage & settings, const QString & data);
 	LoaderObject * addResource(const QUrl & url, const settings::LoadPage & settings);
-	static QUrl guessUrlFromString(const QString &string);
+	static QUrl guessUrlFromString(const QString & string);
 	int httpErrorCode();
 	static bool copyFile(QFile & src, QFile & dst);
 public slots:

--- a/src/lib/multipageloader_p.hh
+++ b/src/lib/multipageloader_p.hh
@@ -79,10 +79,12 @@ private:
 	MultiPageLoaderPrivate & multiPageLoader;
 public:
 	ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, const settings::LoadPage & s);
+	ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, const QString & htmlData, const settings::LoadPage & s);
 	MyQWebPage webPage;
 	LoaderObject lo;
 	int httpErrorCode;
 	const settings::LoadPage settings;
+	QString htmlData;
 public slots:
 	void load();
 	void loadStarted();
@@ -117,6 +119,7 @@ public:
 	const settings::LoadGlobal settings;
 
 	QList<ResourceObject *> resources;
+	QMap<QUrl, QString> hfCache;
 
 	int loading;
 	int progressSum;

--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -96,6 +96,7 @@
  *      aware that if this is too large the header will be printed outside the pdf document. This
  *      can be corrected with the margin.top setting.
  * - \b header.htmlUrl Url for a HTML document to use for the header.
+ * - \b header.htmlSource Source for a HTML document to use for the header.
  *
  * \section pagePdfGlobal Pdf global settings
  * The \ref wkhtmltopdf_global_settings structure contains the following settings:

--- a/src/lib/pdfconverter_p.hh
+++ b/src/lib/pdfconverter_p.hh
@@ -154,13 +154,15 @@ private:
 	MultiPageLoader * tocLoaderOld;
 
 	QHash<QString, PageObject *> urlToPageObj;
+	QMap<QUrl, QString> hfCache;
 
 	Outline * outline;
 	void findLinks(QWebFrame * frame, QVector<QPair<QWebElement, QString> > & local, QVector<QPair<QWebElement, QString> > & external, QHash<QString, QWebElement> & anchors);
 	void endPage(PageObject & object, bool hasHeaderFooter, int objectPage,  int pageNumber);
 	void fillParms(QHash<QString, QString> & parms, int page, const PageObject & object);
 	QString hfreplace(const QString & q, const QHash<QString, QString> & parms);
-	QWebPage * loadHeaderFooter(QString url, const QHash<QString, QString> & parms, const settings::PdfObject & ps);
+	QWebPage * loadHeaderFooter(MultiPageLoader* mpl, QString url, const QHash<QString, QString> & parms, const settings::PdfObject & ps);
+	QWebPage * loadHeaderFooter(MultiPageLoader* mpl, QString url, QString& htmlData, const QHash<QString, QString> & parms, const settings::PdfObject & ps);
     qreal calculateHeaderHeight(PageObject & object, QWebPage & header);
 
 #endif

--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -138,6 +138,7 @@ struct DLL_LOCAL ReflectImpl<HeaderFooter>: public ReflectClass {
 		WKHTMLTOPDF_REFLECT(center);
 		WKHTMLTOPDF_REFLECT(line);
 		WKHTMLTOPDF_REFLECT(htmlUrl);
+		WKHTMLTOPDF_REFLECT(htmlSource);
 		WKHTMLTOPDF_REFLECT(spacing);
 	}
 };
@@ -283,7 +284,7 @@ UnitReal strToUnitReal(const char * o, bool * ok) {
 	else if (!strcasecmp(o+i,"point") || !strcasecmp(o+i,"pt"))
 		u=QPrinter::Point;
 	else {
-		if (ok) ok=false;
+		if (ok) *ok=false;
 		return UnitReal(QString(o).left(i).toDouble()*s, u);
 	}
 	return UnitReal(QString(o).left(i).toDouble(ok)*s, u);
@@ -356,6 +357,7 @@ HeaderFooter::HeaderFooter():
 	center(""),
 	line(false),
 	htmlUrl(""),
+	htmlSource(""),
 	spacing(0.0) {}
 
 Margin::Margin():
@@ -380,9 +382,9 @@ PdfGlobal::PdfGlobal():
 	out(""),
 	documentTitle(""),
 	useCompression(true),
+	viewportSize(""),
 	imageDPI(600),
-	imageQuality(94),
-	viewportSize(""){};
+	imageQuality(94){};
 
 TableOfContent::TableOfContent():
 	useDottedLines(true),

--- a/src/lib/pdfsettings.hh
+++ b/src/lib/pdfsettings.hh
@@ -159,6 +159,8 @@ struct DLL_PUBLIC HeaderFooter {
 	bool line;
 	//! Url of the document the html document that should be used as a header/footer
 	QString htmlUrl;
+	//! Source of the document the html document that should be used as a header/footer
+	QString htmlSource;
 	//! Spacing
 	float spacing;
 };

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -278,6 +278,7 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
  	addarg("footer-right",0,"Right aligned footer text", new QStrSetter(od.footer.right,"text"));
  	addarg("footer-spacing",0,"Spacing between footer and content in mm", new FloatSetter(od.footer.spacing,"real"));
  	addarg("footer-html",0,"Adds a html footer", new QStrSetter(od.footer.htmlUrl,"url"));
+	addarg("footer-src",0,"Adds a html footer from source", new QStrSetter(od.footer.htmlSource,"source"));
  	addarg("header-center",0,"Centered header text", new QStrSetter(od.header.center,"text"));
  	addarg("header-font-name",0,"Set header font name", new QStrSetter(od.header.fontName,"name"));
  	addarg("header-font-size",0,"Set header font size", new IntSetter(od.header.fontSize,"size"));
@@ -286,7 +287,8 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
  	addarg("no-header-line",0,"Do not display line below the header", new ConstSetter<bool>(od.header.line,false));
  	addarg("header-right",0,"Right aligned header text", new QStrSetter(od.header.right,"text"));
  	addarg("header-spacing",0,"Spacing between header and content in mm", new FloatSetter(od.header.spacing,"real"));
- 	addarg("header-html",0,"Adds a html header", new QStrSetter(od.header.htmlUrl,"url"));
+	addarg("header-html",0,"Adds a html header", new QStrSetter(od.header.htmlUrl,"url"));
+	addarg("header-src",0,"Adds a html header from source", new QStrSetter(od.header.htmlSource,"source"));
 
 	addarg("replace",0, "Replace [name] with value in header and footer (repeatable)", new MapSetter<>(od.replacements, "name", "value"));
 

--- a/src/pdf/pdfcommandlineparser.cc
+++ b/src/pdf/pdfcommandlineparser.cc
@@ -177,6 +177,7 @@ void PdfCommandLineParser::parseArguments(int argc, const char ** argv, bool fro
 			ps.footer.left = ps.footer.right = ps.footer.center = "";
 			ps.header.line = ps.footer.line = false;
 			ps.header.htmlUrl = ps.footer.htmlUrl = "";
+			ps.header.htmlSource = ps.footer.htmlSource = "";
 			ps.includeInOutline = false;
 
 			continue;


### PR DESCRIPTION
This commit adds options for setting HTML source directly!
Also I added some kind of file cache to enable reading from pipes. Pipes can only be read once but until now, header/footer files are read multiple times. If you try to get header/footer from a pipe, it is read the first time while measuring its height. It will read the second time while rendering its content to the PDF, but the pipe is emtpy this time.

In short this patch allows wkhtmltopdf to be called this way (set HTML directly):
```wkhtmltopdf --footer-src "$(cat footer.html)" content.html out.pdf```

Or to call it this way (reading from pipe /dev/fd/xx):
```wkhtmltopdf --footer-html <(cat footer.html) content.html out.pdf```

Some Q_UNUSED and initialisation reordering solved all compiler warnings for me!