### PR TITLE
Fix the directory to execute tar in build_posix_local

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1055,7 +1055,7 @@ def build_posix_local(config, basedir):
     shell('cp ../../../include/wkhtmltox/*.h ../wkhtmltox-%s/include/wkhtmltox' % version)
     shell('cp ../../../include/wkhtmltox/dll*.inc ../wkhtmltox-%s/include/wkhtmltox' % version)
 
-    os.chdir(basedir)
+    os.chdir(os.path.join(basedir, config))
     shell('tar -c -v -f ../wkhtmltox-%s_local-%s.tar wkhtmltox-%s/' % (version, platform.node(), version))
     shell('xz --compress --force --verbose -9 ../wkhtmltox-%s_local-%s.tar' % (version, platform.node()))
 


### PR DESCRIPTION
I've tried to execute "scripts/build.py posix-local" on CentOS 7.
But it failed by errors with the following output.

```
tar: wkhtmltox-0.12.1: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
tar -c -v -f ../wkhtmltox-0.12.1_local-centos7.tar wkhtmltox-0.12.1/
command failed: exit code 512
```

This pull request changes the directory to execute tar.
