### PR TITLE
Add option to force jpeg compression of all images as long as the jpeg-...

### DIFF
--- a/include/wkhtmltox/pdfsettings.hh
+++ b/include/wkhtmltox/pdfsettings.hh
@@ -128,6 +128,8 @@ struct DLL_PUBLIC PdfGlobal {
 
 	bool useCompression;
 
+  bool forceJPEG;
+
 	//! Margin related settings
 	Margin margin;
 

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -403,6 +403,7 @@ void PdfConverterPrivate::pagesLoaded(bool ok) {
 	printer->printEngine()->setProperty(QPrintEngine::PPK_UseCompression, settings.useCompression);
 	printer->printEngine()->setProperty(QPrintEngine::PPK_ImageQuality, settings.imageQuality);
 	printer->printEngine()->setProperty(QPrintEngine::PPK_ImageDPI, settings.imageDPI);
+	printer->printEngine()->setProperty(QPrintEngine::PPK_ForceJPEG, settings.forceJPEG);
 
 	painter = new QPainter();
 

--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -122,6 +122,7 @@ struct DLL_LOCAL ReflectImpl<PdfGlobal>: public ReflectClass {
 		WKHTMLTOPDF_REFLECT(dumpRenderTree);
 		WKHTMLTOPDF_REFLECT(documentTitle);
 		WKHTMLTOPDF_REFLECT(useCompression);
+		WKHTMLTOPDF_REFLECT(forceJPEG);
 		WKHTMLTOPDF_REFLECT(margin);
 		WKHTMLTOPDF_REFLECT(imageDPI);
 		WKHTMLTOPDF_REFLECT(imageQuality);
@@ -382,6 +383,7 @@ PdfGlobal::PdfGlobal():
 	dumpRenderTree(""),
 	documentTitle(""),
 	useCompression(true),
+	forceJPEG(false),
 	viewportSize(""),
 	imageDPI(600),
 	imageQuality(94){};

--- a/src/lib/pdfsettings.hh
+++ b/src/lib/pdfsettings.hh
@@ -131,6 +131,8 @@ struct DLL_PUBLIC PdfGlobal {
 
 	bool useCompression;
 
+	bool forceJPEG;
+
 	//! Margin related settings
 	Margin margin;
 

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -212,8 +212,10 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
  	qthack(true);
 
 	addarg("image-quality", 0, "When jpeg compressing images use this quality", new IntSetter(s.imageQuality,"integer"));
-	addarg("image-dpi", 0, "When embedding images scale them down to this dpi", new IntSetter(s.imageDPI, "integer"));
+	addarg("image-dpi", 0, "When embedding images scale them down to this dpi. Set to 0 to never shrink images.", new IntSetter(s.imageDPI, "integer"));
 	addarg("no-pdf-compression", 0 , "Do not use lossless compression on pdf objects", new ConstSetter<bool>(s.useCompression,false));
+	addarg("force-jpeg-compression", 0 , "Use jpeg compression for all images as long as they take up less space than deflate compression. "
+	  "By default only scaled images which were originally jpeg compressed will be jpeg compressed in the output.", new ConstSetter<bool>(s.forceJPEG,true));
 
 #ifdef Q_OS_UNIX
  	addarg("use-xserver",0,"Use the X server (some plugins and other stuff might not work without X11)", new ConstSetter<bool>(s.useGraphics,true));


### PR DESCRIPTION
compressed versions are smaller than the deflated versions (which was the pre-2f2e142 behaviour of wkhtmltopdf-qt).