### PR TITLE
Make background transparent in generated PDF (instead of white).

### DIFF
--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -883,6 +883,12 @@ void PdfConverterPrivate::beginPrintObject(PageObject & obj) {
 	currentObject = obj.number;
 
 	if (!obj.loaderObject || obj.loaderObject->skip) return;
+
+	// Make background transparent. If a non-transparent background is desired, set the background CSS property on <body>.
+	QPalette pal = obj.loaderObject->page.palette();
+	pal.setColor(QPalette::Base, QColor(Qt::transparent));
+	obj.loaderObject->page.setPalette(pal);
+
 	const settings::PdfObject & ps = obj.settings;
 	pageHasHeaderFooter = ps.header.line || ps.footer.line ||
 		!ps.header.left.isEmpty() || !ps.footer.left.isEmpty() ||


### PR DESCRIPTION
Previously, wkhtmltopdf rendered a white background explicitly. This makes it impossible to use the generated PDF as an overlay for another PDF (merging the PDFs using other tools). This patch removes the default-white background. Note that it is still possible to force the white background using &lt;body style="background: white"&gt;, but I don't think that is normally useful.