### PR TITLE
fixes #2142

### DIFF
--- a/src/lib/imageconverter.cc
+++ b/src/lib/imageconverter.cc
@@ -45,7 +45,7 @@ namespace wkhtmltopdf {
 
 ImageConverterPrivate::ImageConverterPrivate(ImageConverter & o, wkhtmltopdf::settings::ImageGlobal & s, const QString * data):
 	settings(s),
-	loader(s.loadGlobal),
+	loader(s.loadGlobal, true),
 	out(o) {
 	out.emitCheckboxSvgs(s.loadPage);
 	if (data) inputData = *data;


### PR DESCRIPTION
To be quite honest, I'm really not aware of any possible side-effects of
turning the loader into a mainLoader.

But it does fix #2142. wkhtmltoimage now respects `--javascript-delay`
and `--window-status` commandline flags.

So far, in all our tests on debian-linux, wkhtmltoimage works and
behaves as expected when the MultiPageLoader is configured as a
mainLoader as by this patch.