### PR TITLE
Fix typo in pdfdocparts.cc

### DIFF
--- a/src/pdf/pdfdocparts.cc
+++ b/src/pdf/pdfdocparts.cc
@@ -263,7 +263,7 @@ void PdfCommandLineParser::outputOutlineDoc(Outputter * o) const {
 		"book marks, this can be enabled by specifying the --outline switch. "
 		"The outlines are generated based on the <h?> tags, for a in-depth "
 		"description of how this is done see the ");
-	o->sectionLink("Table Of Contest");
+	o->sectionLink("Table Of Content");
 	o->text(" section. ");
 	o->endParagraph();
 	o->paragraph(


### PR DESCRIPTION
In the section "Outlines" there was a reference to the section "Table of Contest". Changed this reference to point to the "Table Of Content" section.