### PR TITLE
Resolve external links (handling relative links different according to flag)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Emmanuel Bouthenot  <kolter@openics.org>
 Artem Butusov       <art.sormy@gmail.com>
 Michael Nitze       <michael.nitze@online.de>
 theirix             <theirix@gmail.com>
+Kay Lukas           <kay.lukas@gmail.com>
 rainabba
 Mehdi Abbad
 Lyes Amazouz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ v0.12.3 (unreleased)
 * removed support for CentOS 5 builds
 * update OpenSSL to 1.0.2a and xz to 5.2.1
 * downgrade libpng to 1.2.53
+* **#1843**: add --keep-relative-links and --resolve-relative-links to resolve relative links
 * **#2104**: renamed COPYING to LICENSE
 * **#2190**: do not depend on ICU even if it is already installed
 * **#2280**: do not allow data URIs for --header-html or --footer-html

--- a/include/wkhtmltox/pdfsettings.hh
+++ b/include/wkhtmltox/pdfsettings.hh
@@ -87,6 +87,9 @@ struct DLL_PUBLIC PdfGlobal {
 
 	//! Should we use the graphics system
 	bool useGraphics;
+	
+	//! Should relative links be resolved
+	bool resolveRelativeLinks;
 
 	//! Should we orientate in landscape or portrate
 	QPrinter::Orientation orientation;

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -579,9 +579,7 @@ void PdfConverterPrivate::findLinks(QWebFrame * frame, QVector<QPair<QWebElement
 					}
 				}
 			} else if (uexternal) {
-				// pass the unresolved url to WebKit. WebKit will resolve it
-				// depending upon the type of url - filepath, web-uri etc.
-				external.push_back( qMakePair(elm, h) );
+				external.push_back( qMakePair(elm, settings.resolveRelativeLinks ? href.toString() : h) );
 			}
 		}
 	}

--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -109,6 +109,7 @@ struct DLL_LOCAL ReflectImpl<PdfGlobal>: public ReflectClass {
 		WKHTMLTOPDF_REFLECT(size);
 		WKHTMLTOPDF_REFLECT(quiet);
 		WKHTMLTOPDF_REFLECT(useGraphics);
+		WKHTMLTOPDF_REFLECT(resolveRelativeLinks);
 		WKHTMLTOPDF_REFLECT(orientation);
 		WKHTMLTOPDF_REFLECT(colorMode);
 		WKHTMLTOPDF_REFLECT(resolution);
@@ -367,6 +368,7 @@ Margin::Margin():
 PdfGlobal::PdfGlobal():
 	quiet(false),
 	useGraphics(false),
+	resolveRelativeLinks(true),
 	orientation(QPrinter::Portrait),
 	colorMode(QPrinter::Color),
 	resolution(QPrinter::HighResolution),

--- a/src/lib/pdfsettings.hh
+++ b/src/lib/pdfsettings.hh
@@ -91,6 +91,9 @@ struct DLL_PUBLIC PdfGlobal {
 	//! Should we use the graphics system
 	bool useGraphics;
 
+	//! Should relative links be resolved or kept as-is
+	bool resolveRelativeLinks;
+
 	//! Should we orientate in landscape or portrate
 	QPrinter::Orientation orientation;
 

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -257,6 +257,8 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
  	addarg("enable-internal-links",0,"Make local links", new ConstSetter<bool>(od.useLocalLinks, true));
  	addarg("disable-external-links",0,"Do not make links to remote web pages", new ConstSetter<bool>(od.useExternalLinks, false));
  	addarg("enable-external-links",0,"Make links to remote web pages", new ConstSetter<bool>(od.useExternalLinks, true));
+ 	addarg("resolve-relative-links", 0, "Resolve relative external links into absolute links", new ConstSetter<bool>(s.resolveRelativeLinks, true));
+ 	addarg("keep-relative-links", 0, "Keep relative external links as relative external links", new ConstSetter<bool>(s.resolveRelativeLinks, false));
 
 	addarg("enable-toc-back-links",0,"Link from section header to toc", new ConstSetter<bool>(od.toc.backLinks,true));
 	addarg("disable-toc-back-links",0,"Do not link from section header to toc", new ConstSetter<bool>(od.toc.backLinks,false));


### PR DESCRIPTION
Added a flag --resolve-external-links, to make it possible to resolve all relative links in the html document to absolute links.

Solves issue #1843.