### PR TITLE
support for localhost/127.0.0.1 proxy bypass

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Artem Butusov       <art.sormy@gmail.com>
 Michael Nitze       <michael.nitze@online.de>
 theirix             <theirix@gmail.com>
 Kay Lukas           <kay.lukas@gmail.com>
+Emil Lerch          <emil@lerch.org>
 rainabba
 Mehdi Abbad
 Lyes Amazouz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v0.12.3 (unreleased)
 * **#2190**: do not depend on ICU even if it is already installed
 * **#2280**: do not allow data URIs for --header-html or --footer-html
 * **#2322**: fix broken debug builds with MSVC
+* **#2355**: add support for proxy bypass for specific hosts with --bypass-proxy-for
 
 v0.12.2.1 (2015-01-19)
 ----------------------

--- a/include/wkhtmltox/loadsettings.hh
+++ b/include/wkhtmltox/loadsettings.hh
@@ -117,6 +117,9 @@ struct DLL_PUBLIC LoadPage {
 
 	QString cacheDir;
 	static QList<QString> mediaFilesExtensions;
+
+	// Hosts to bypass
+	QList< QString > bypassProxyForHosts;
 };
 
 DLL_PUBLIC LoadPage::LoadErrorHandling strToLoadErrorHandling(const char * s, bool * ok=0);

--- a/src/lib/loadsettings.hh
+++ b/src/lib/loadsettings.hh
@@ -120,6 +120,9 @@ struct DLL_PUBLIC LoadPage {
 
 	QString cacheDir;
 	static QList<QString> mediaFilesExtensions;
+
+	// Hosts to bypass
+	QList< QString > bypassProxyForHosts;
 };
 
 DLL_PUBLIC LoadPage::LoadErrorHandling strToLoadErrorHandling(const char * s, bool * ok=0);

--- a/src/lib/multipageloader_p.hh
+++ b/src/lib/multipageloader_p.hh
@@ -35,6 +35,16 @@
 #include "dllbegin.inc"
 namespace wkhtmltopdf {
 
+class DLL_LOCAL MyNetworkProxyFactory: public QObject, public QNetworkProxyFactory {
+	Q_OBJECT
+private:
+	QList<QString> bypassHosts;
+	QList<QNetworkProxy> originalProxy, noProxy;
+public:
+	MyNetworkProxyFactory(QNetworkProxy defaultProxy, QList<QString> bypassHosts);
+	QList<QNetworkProxy> queryProxy (const QNetworkProxyQuery & query);
+};
+
 class DLL_LOCAL MyNetworkAccessManager: public QNetworkAccessManager {
 	Q_OBJECT
 private:

--- a/src/lib/reflect.cc
+++ b/src/lib/reflect.cc
@@ -76,6 +76,7 @@ ReflectImpl<LoadPage>::ReflectImpl(LoadPage & c) {
 	WKHTMLTOPDF_REFLECT(radiobuttonSvg);
 	WKHTMLTOPDF_REFLECT(radiobuttonCheckedSvg);
 	WKHTMLTOPDF_REFLECT(cacheDir);
+	WKHTMLTOPDF_REFLECT(bypassProxyForHosts);
 }
 
 ReflectImpl<Web>::ReflectImpl(Web & c) {

--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -203,6 +203,7 @@ void CommandLineParserBase::addPageLoadArgs(LoadPage & s) {
 	extended(true);
 	qthack(false);
 	addarg("proxy",'p',"Use a proxy", new ProxySetter(s.proxy, "proxy"));
+	addarg("bypass-proxy-for", 0, "Bypass proxy for host (repeatable)", new StringListSetter(s.bypassProxyForHosts, "value"));
 	addarg("username",0,"HTTP Authentication username", new QStrSetter(s.username, "username"));
 	addarg("password",0,"HTTP Authentication password", new QStrSetter(s.password, "password"));
 	addarg("load-error-handling", 0, "Specify how to handle pages that fail to load: abort, ignore or skip", new LoadErrorHandlingSetting(s.loadErrorHandling, "handler"));


### PR DESCRIPTION
This PR addresses #1565 and #2130. It is currently using hardcoded values for localhost (localhost and 127.0.0.1) for bypass. I started wiring this into the settings system but was getting seg faults so I'm clearly doing something wrong there. I'll create a new PR for customization of the bypass values through the settings once I get that worked out.

This was originally worked off rev 7f74d893635d275f9450bf5f12c454a9c27672bd.