### PR TITLE
Fix DPI

### DIFF
--- a/src/lib/imageconverter.cc
+++ b/src/lib/imageconverter.cc
@@ -45,7 +45,7 @@ namespace wkhtmltopdf {
 
 ImageConverterPrivate::ImageConverterPrivate(ImageConverter & o, wkhtmltopdf::settings::ImageGlobal & s, const QString * data):
 	settings(s),
-	loader(s.loadGlobal, true),
+	loader(s.loadGlobal, 96, true),
 	out(o) {
 	out.emitCheckboxSvgs(s.loadPage);
 	if (data) inputData = *data;

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -213,7 +213,9 @@ ResourceObject::ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, con
 	}
 
 	webPage.setNetworkAccessManager(&networkAccessManager);
-	webPage.mainFrame()->setZoomFactor(settings.zoomFactor);
+
+	double devicePixelRatio = multiPageLoader.dpi / 96.; // The used version of WebKit always renders at 96 DPI when no zoom is applied. It does not fully support a device pixel ratio != 1 natively.
+	webPage.mainFrame()->setZoomFactor(devicePixelRatio * settings.zoomFactor); // Zoom in the page to achieve a higher DPI.
 }
 
 /*!
@@ -525,8 +527,8 @@ bool MultiPageLoader::copyFile(QFile & src, QFile & dst) {
 	return true;
 }
 
-MultiPageLoaderPrivate::MultiPageLoaderPrivate(const settings::LoadGlobal & s, MultiPageLoader & o):
-	outer(o), settings(s) {
+MultiPageLoaderPrivate::MultiPageLoaderPrivate(const settings::LoadGlobal & s, int dpi_, MultiPageLoader & o):
+	outer(o), settings(s), dpi(dpi_) {
 
 	cookieJar = new MyCookieJar();
 
@@ -588,8 +590,8 @@ void MultiPageLoaderPrivate::fail() {
   \brief Construct a multipage loader object, load settings read from the supplied settings
   \param s The settings to be used while loading pages
 */
-MultiPageLoader::MultiPageLoader(settings::LoadGlobal & s, bool mainLoader):
-	d(new MultiPageLoaderPrivate(s, *this)) {
+MultiPageLoader::MultiPageLoader(settings::LoadGlobal & s, int dpi, bool mainLoader):
+	d(new MultiPageLoaderPrivate(s, dpi, *this)) {
 	d->isMainLoader = mainLoader;
 }
 

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -216,6 +216,7 @@ ResourceObject::ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, con
 
 	double devicePixelRatio = multiPageLoader.dpi / 96.; // The used version of WebKit always renders at 96 DPI when no zoom is applied. It does not fully support a device pixel ratio != 1 natively.
 	webPage.mainFrame()->setZoomFactor(devicePixelRatio * settings.zoomFactor); // Zoom in the page to achieve a higher DPI.
+	webPage.setDevicePixelRatio(devicePixelRatio); // Fix CSS media queries (does not affect anything else).
 }
 
 /*!

--- a/src/lib/multipageloader.hh
+++ b/src/lib/multipageloader.hh
@@ -48,7 +48,7 @@ class DLL_LOCAL MultiPageLoaderPrivate;
 class DLL_LOCAL MultiPageLoader: public QObject {
 	Q_OBJECT
 public:
-	MultiPageLoader(settings::LoadGlobal & s, bool mainLoader = false);
+	MultiPageLoader(settings::LoadGlobal & s, int dpi, bool mainLoader = false);
 	~MultiPageLoader();
 	LoaderObject * addResource(const QString & url, const settings::LoadPage & settings, const QString * data=NULL);
 	LoaderObject * addResource(const QUrl & url, const settings::LoadPage & settings);

--- a/src/lib/multipageloader_p.hh
+++ b/src/lib/multipageloader_p.hh
@@ -135,8 +135,9 @@ public:
 	bool hasError;
 	bool finishedEmitted;
 	TempFile tempIn;
+	int dpi;
 
-	MultiPageLoaderPrivate(const settings::LoadGlobal & settings, MultiPageLoader & o);
+	MultiPageLoaderPrivate(const settings::LoadGlobal & settings, int dpi, MultiPageLoader & o);
 	~MultiPageLoaderPrivate();
 	LoaderObject * addResource(const QUrl & url, const settings::LoadPage & settings);
 	void load();

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -76,10 +76,10 @@ bool DLL_LOCAL looksLikeHtmlAndNotAUrl(QString str) {
 }
 
 PdfConverterPrivate::PdfConverterPrivate(PdfGlobal & s, PdfConverter & o) :
-	settings(s), pageLoader(s.load, true),
+	settings(s), pageLoader(s.load, settings.dpi, true),
 	out(o), printer(0), painter(0)
 #ifdef __EXTENSIVE_WKHTMLTOPDF_QT_HACK__
-    , webPrinter(0), measuringHFLoader(s.load), hfLoader(s.load), tocLoader1(s.load), tocLoader2(s.load)
+	, webPrinter(0), measuringHFLoader(s.load, settings.dpi), hfLoader(s.load, settings.dpi), tocLoader1(s.load, settings.dpi), tocLoader2(s.load, settings.dpi)
 	, tocLoader(&tocLoader1), tocLoaderOld(&tocLoader2)
     , outline(0), currentHeader(0), currentFooter(0)
 #endif
@@ -265,7 +265,7 @@ qreal PdfConverterPrivate::calculateHeaderHeight(PageObject & object, QWebPage &
 
 QPrinter * PdfConverterPrivate::createPrinter(const QString & tempFile) {
     QPrinter * printer = new QPrinter(settings.resolution);
-    if (settings.dpi != -1) printer->setResolution(settings.dpi);
+    printer->setResolution(settings.dpi);
     //Tell the printer object to print the file <out>
 
     printer->setOutputFileName(tempFile);
@@ -344,7 +344,7 @@ void PdfConverterPrivate::pagesLoaded(bool ok) {
 	  lout = tempOut.create(".pdf");
 
 	printer = new QPrinter(settings.resolution);
-	if (settings.dpi != -1) printer->setResolution(settings.dpi);
+	printer->setResolution(settings.dpi);
 	//Tell the printer object to print the file <out>
 
 	printer->setOutputFileName(lout);

--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -372,7 +372,7 @@ PdfGlobal::PdfGlobal():
 	orientation(QPrinter::Portrait),
 	colorMode(QPrinter::Color),
 	resolution(QPrinter::HighResolution),
-	dpi(-1),
+	dpi(96),
 	pageOffset(0),
 	copies(1),
 	collate(true),


### PR DESCRIPTION
Triggered by a few notification e-mails I got referencing my previous pull requests ( https://github.com/wkhtmltopdf/qt/pull/12 and https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1863 ), I thought I'd look into it again. This pull request should fix several open issues related to DPI (e.g. https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2290) and font size and kerning; at least those referenced by the aforementioned pull requests. The output should also be correctly sized regardless of the operating system and Windows text size settings because `qt_defaultDpi()` is no longer used (although I tested it only on Windows), so that the `--zoom 0.78125` workaround mentioned in https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2156 should no longer be necessary.

The version of WebKit used by Qt/wkhtmltopdf seems to assume 96 DPI, and round off values to multiples of 1/96 inch pixels. Therefore, setting the output resolution on the QPrinter was ineffective.

Before this commit (and the corresponding commit in the wkhtmltopdf qt repository), Qt scaled WebKit's output by a factor of `qt_defaultDpi()` to match the printer DPI. WebKit still rounded the results to whole pixels at 96 DPI, before the values were scaled to the larger DPI. Therefore, increasing the printer DPI did not actually increase the apparent DPI of the rendered content.

The WebKit zoom factor is applied before the values are rounded. Effectively, WebKit thus produces output with `96 * zoom_factor` pixels per CSS inch. By setting the zoom_factor to `desired_dpi / 96` the desired resolution (pixels per CSS inch) can be achieved. WebKit then renders with the desired DPI, but Qt scales the result by `desired_dpi / qt_defaultDpi()` again when painting to the PDF printer. If this scaling is removed, the output ends up with the right DPI, and the right scale; i.e. one CSS inch corresponds to one inch on the printed page.

I am not sure whether this pull request plays nicely due to the changes in the qt git submodule, but creating a pull request in the submodule as well seems redundant. If required, the corresponding commits are at https://github.com/pvandertak/qt/tree/dpi_fix.

Some other remarks related to this change:
1. The version of WebKit in Qt 5.4 seems to have better support for devicePixelRatio/deviceScaleFactor that should likely be used instead of the zoom level. This version does not, and only works with 96 DPI. I don't see any downside to using the zoom level for achieving higher DPI, though. As far as I can see, it gives much better results for font kerning, correct positioning, tiny borders, etc.
2. I cannot find a good reason why `qt_defaultDpi()` was used originally instead of 96. I think scaling by qt_defaultDpi() was incorrect, as it caused the rendered page to be scaled incorrectly when `qt_defaultDpi() != 96`. (See https://github.com/wkhtmltopdf/qt/pull/12) The scaling was originally introduced in http://trac.webkit.org/changeset/32293 , but the commit message does not provide any info why `qt_defaultDpi()` was used instead of 96.
3. I set `--dpi`'s default value to 96 since that corresponds to the original behavior. Probably a higher value would be a better default, as it gives better quality without actually costing much (since PDF is a vector format, and raster image resolution is controlled by a different DPI setting anyway).
4. I hardcoded the DPI in wkhtmltoimage to 96, because that corresponds to what it used to do. It would probably be better to make it configurable in wkhtmltoimage just like it is in wkhtmltopdf.
5. I don't think the `-l` flag does anything other than setting the resolution to a preset value, and given the issues with the DPI it did not seem to work reliably. Now that the DPI setting works reliably, perhaps the `-l` setting should be removed in favor of setting the DPI explicitly.
