### PR TITLE
Fix gmake determination call

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1077,7 +1077,7 @@ def build_posix_local(config, basedir):
     app    = os.path.join(basedir, config, 'app')
     qt     = os.path.join(basedir, config, 'qt')
     dist   = os.path.join(basedir, config, 'wkhtmltox-%s' % version)
-    make   = get_output('which gmake') and 'gmake' or 'make'
+    make   = get_output('which', 'gmake') and 'gmake' or 'make'
 
     mkdir_p(qt)
     mkdir_p(app)


### PR DESCRIPTION
Fix the function call that tries to determine whether gmake is available. It would always default to make in it's previous incarnation.