### PR TITLE
Allow email-adress as username

### DIFF
--- a/src/lib/loadsettings.cc
+++ b/src/lib/loadsettings.cc
@@ -80,7 +80,7 @@ Proxy strToProxy(const char * proxy, bool * ok) {
 	}
 
 	//Read username and password
-	char * val = (char *) strchr(proxy,'@');
+	char * val = (char *) strrchr(proxy,'@');
 	p.user = p.password = "";
 	if (val != NULL) {
 		p.user = QString(proxy).left(val-proxy);


### PR DESCRIPTION
Apparently a email-adress as username does not work, should use strrchar instead