### PR TITLE
support for ubuntu multiarch dpkg build

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -581,8 +581,9 @@ def fpm_params(cfg, ver):
 
     for depend in setup['runtime_packages'].split():
         if setup['packaging_tool'] == 'apt':
-            version = get_output('dpkg-query', '-W', '-f=${Version}', depend)
+            version = get_output('dpkg-query', '-W', '-f=${Version} ', depend)
             if version:
+                version = version.split(' ')[0]
                 output += ' --depends "%s >= %s"' % (depend, version)
             else:
                 output += ' --depends %s' % depend


### PR DESCRIPTION
example:
$ dpkg-query -W -f='${Version}' libjpeg-turbo8; echo
1.3.0-0ubuntu21.3.0-0ubuntu2

both version will be appended, now running with a space:
$ dpkg-query -W -f='${Version}'\  libjpeg-turbo8; echo
1.3.0-0ubuntu2 1.3.0-0ubuntu2