### PR TITLE
Spelling patch

### DIFF
--- a/examples/image_c_api.c
+++ b/examples/image_c_api.c
@@ -82,9 +82,9 @@ int main() {
 	/* Call the waring function when a warning is issued */
 	wkhtmltoimage_set_warning_callback(c, warning);
 
-	/* Perform the actual convertion */
+	/* Perform the actual conversion */
 	if (!wkhtmltoimage_convert(c))
-		fprintf(stderr, "Convertion failed!");
+		fprintf(stderr, "Conversion failed!");
 
 	/* Output possible http error code encountered */
 	printf("httpErrorCode: %d\n", wkhtmltoimage_http_error_code(c));

--- a/examples/pdf_c_api.c
+++ b/examples/pdf_c_api.c
@@ -96,9 +96,9 @@ int main() {
 	 */
 	wkhtmltopdf_add_object(c, os, NULL);
 
-	/* Perform the actual convertion */
+	/* Perform the actual conversion */
 	if (!wkhtmltopdf_convert(c))
-		fprintf(stderr, "Convertion failed!");
+		fprintf(stderr, "Conversion failed!");
 
 	/* Output possible http error code encountered */
 	printf("httpErrorCode: %d\n", wkhtmltopdf_http_error_code(c));

--- a/include/wkhtmltox/converter.hh
+++ b/include/wkhtmltox/converter.hh
@@ -48,7 +48,7 @@ signals:
 	void radiobuttonSvgChanged(const QString & path);
 	void radiobuttonCheckedSvgChanged(const QString & path);
 public slots:
-    void beginConvertion();
+    void beginConversion();
 	bool convert();
 	void cancel();
 protected:

--- a/src/lib/converter.cc
+++ b/src/lib/converter.cc
@@ -60,7 +60,7 @@ void ConverterPrivate::updateWebSettings(QWebSettings * ws, const settings::Web 
 
 void ConverterPrivate::fail() {
 	error = true;
-	convertionDone = true;
+	conversionDone = true;
 	clearResources();
 	emit outer().finished(false);
 	qApp->exit(0); // quit qt's event handling
@@ -88,9 +88,9 @@ void ConverterPrivate::cancel() {
 }
 
 bool ConverterPrivate::convert() {
-	convertionDone=false;
+	conversionDone=false;
 	beginConvert();
-	while (!convertionDone)
+	while (!conversionDone)
 		qApp->processEvents(QEventLoop::WaitForMoreEvents | QEventLoop::AllEvents);
 	return !error;
 }
@@ -138,7 +138,7 @@ int Converter::httpErrorCode() {
   \brief Start a asynchronous conversion of html pages to a pdf document.
   Once conversion is done an finished signal will be emitted
 */
-void Converter::beginConvertion() {
+void Converter::beginConversion() {
 	priv().beginConvert();
 }
 

--- a/src/lib/converter.hh
+++ b/src/lib/converter.hh
@@ -51,7 +51,7 @@ signals:
 	void radiobuttonSvgChanged(const QString & path);
 	void radiobuttonCheckedSvgChanged(const QString & path);
 public slots:
-    void beginConvertion();
+    void beginConversion();
 	bool convert();
 	void cancel();
 protected:

--- a/src/lib/converter_p.hh
+++ b/src/lib/converter_p.hh
@@ -45,7 +45,7 @@ protected:
 	virtual Converter & outer() = 0;
 	int errorCode;
 
-	bool convertionDone;
+	bool conversionDone;
 
 	void updateWebSettings(QWebSettings * ws, const settings::Web & s) const;
 public slots:

--- a/src/lib/imageconverter.cc
+++ b/src/lib/imageconverter.cc
@@ -62,7 +62,7 @@ ImageConverterPrivate::ImageConverterPrivate(ImageConverter & o, wkhtmltopdf::se
 
 void ImageConverterPrivate::beginConvert() {
 	error = false;
-	convertionDone = false;
+	conversionDone = false;
 	errorCode = 0;
 	progressString = "0%";
 	loaderObject = loader.addResource(settings.in, settings.loadPage, &inputData);
@@ -226,7 +226,7 @@ void ImageConverterPrivate::pagesLoaded(bool ok) {
 
 	currentPhase = 2;
 	emit out.phaseChanged();
-	convertionDone = true;
+	conversionDone = true;
 	emit out.finished(true);
 
 	qApp->exit(0); // quit qt's event handling

--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -1,4 +1,4 @@
-// -*- mode: c++; tab-width: 4; indent-tabs-mode: t; eval: (progn (c-set-style "stroustrup") (c-set-offset 'innamespace 0)); -*-
+n// -*- mode: c++; tab-width: 4; indent-tabs-mode: t; eval: (progn (c-set-style "stroustrup") (c-set-offset 'innamespace 0)); -*-
 // vi:set ts=4 sts=4 sw=4 noet :
 //
 // Copyright 2010 wkhtmltopdf authors
@@ -76,7 +76,7 @@
  * - \b load.debugJavascript Forward javascript warnings and errors to the warning callback.
  *      Must be either "true" or "false".
  * - \b load.loadErrorHandling How should we handle obejcts that fail to load. Must be one of:
- *      - "abort" Abort the convertion process
+ *      - "abort" Abort the conversion process
  *      - "skip" Do not add the object to the final output
  *      - "ignore" Try to add the object to the final output.
  * - \b load.proxy String describing what proxy to use when loading the object.
@@ -530,7 +530,7 @@ CAPI(void) wkhtmltopdf_set_finished_callback(wkhtmltopdf_converter * converter, 
 }
 
 //CAPI(void) wkhtmltopdf_begin_conversion(wkhtmltopdf_converter * converter) {
-//	reinterpret_cast<MyPdfConverter *>(converter)->converter.beginConvertion();
+//	reinterpret_cast<MyPdfConverter *>(converter)->converter.beginConversion();
 //}
 
 /**
@@ -684,5 +684,6 @@ CAPI(long) wkhtmltopdf_get_output(wkhtmltopdf_converter * converter, const unsig
 //  LocalWords:  includeInOutline pagesCount tocXsl xsl struct typedef str CAPI
 //  LocalWords:  param STRINGIZEE STRINGIZE deinit qApp strcpy wkhtmltox arg ug
 //  LocalWords:  WS MACX MyLooksStyle setStyle isNull qstrncpy MyPdfConverter
-//  LocalWords:  beginConvertion paragm addResource currentPhase phaseCount
-//  LocalWords:  urrent http httpErrorCode QByteArray constData
+//  LocalWords:  beginConversion beginConvertion paragm addResource
+//  LocalWords:  currentPhase phaseCount urrent http httpErrorCode QByteArray
+//  LocalWords:  constData

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -1047,7 +1047,7 @@ void PdfConverterPrivate::printDocument() {
 	currentPhase = 2;
 #endif
 	emit out.phaseChanged();
-	convertionDone = true;
+	conversionDone = true;
 	emit out.finished(true);
 
 	qApp->exit(0); // quit qt's event handling


### PR DESCRIPTION
Another of English's "exceptions which prove the rule": while converter is correct, convertion is not and should be conversion.