### PR TITLE
issue[2659]: Fix failed gem fpm install  in build.py by attempting without '-N' option

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -722,7 +722,8 @@ def build_setup_schroot(config, basedir):
     install_packages('git', 'debootstrap', 'schroot', 'rinse', 'debian-archive-keyring',
                      'build-essential', 'ruby', 'ruby-dev', 'libffi-dev', 'tar', 'xz-utils')
     if not get_output('which', 'fpm'):
-        shell('gem install -V fpm -N')
+        if not get_output('gem install -V fpm -N'):
+                get_output('gem install -V fpm')
 
     login  = os.environ.get('SUDO_USER') or get_output('logname')
     target = config.split('-', 2)[2]


### PR DESCRIPTION
-N option wasn't present in my Ubuntu Trusty build attempt. Trying again after failure without the additional option present is proposed.