### PR TITLE
Provide a proper error message if qt submodule is not checked out

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -667,6 +667,10 @@ def build_deplibs(config, basedir, **kwargs):
         rmdir(srcdir)
 
 def build_qt(qtdir, make_cmd, configure_cmd):
+    if not exists(os.path.join(qtdir, configure_cmd.split(' ')[0])):
+        error('\nIt seems you did not clone the repository with the --recursive argument, '
+              'use `git submodule update --init --recursive` to update submodules')
+
     configured = ''
     if exists(os.path.join(qtdir, 'configured')):
         configured = open(os.path.join(qtdir, 'configured'), 'r').read()


### PR DESCRIPTION
If a user tries to run `./scripts/build.py <target>` and did not clone with `--recursive` or ran `git submodule update --init --recursive`, he'll get this error message

```
It seems you did not clone the repository with the --recursive argument 
use `git submodule update --init --recursive` to update submodules
```
refs #2673