### PR TITLE
openssl fix; unicode fixes; new wkhtmltox tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ gitcontrol.bat
 gitcmd.lnk
 *.tar.bz2
 *.pyc
+*.user

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ wkhtmltopdf.app/
 wkhtmltopdf.xcodeproj/
 release*/
 test/
-static-build/
+static-build*/
 .obj/
 doc/
 libdoc/

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -269,7 +269,7 @@ enabled=1
 DEPENDENT_LIBS = {
     'openssl': {
         'order' : 1,
-        'url'   : 'https://openssl.org/source/openssl-1.0.2f.tar.gz',
+        'url'   : 'https://openssl.org/source/old/1.0.2/openssl-1.0.2f.tar.gz',
         'sha1'  : '2047c592a6e5a42bd37970bdb4a931428110a927',
         'build' : {
             'msvc*-win32*': {

--- a/src/image/image.pro
+++ b/src/image/image.pro
@@ -47,4 +47,4 @@ CONFIG(shared, shared|static) {
 }
 
 # Input
-SOURCES += wkhtmltoimage.cc imagearguments.cc imagecommandlineparser.cc imagedocparts.cc
+SOURCES += wkhtmltoimage.cc imagearguments.cc imagecommandlineparser.cc imagedocparts.cc main.cc

--- a/src/image/imagecommandlineparser.cc
+++ b/src/image/imagecommandlineparser.cc
@@ -109,17 +109,18 @@ void ImageCommandLineParser::readme(FILE * fd, bool html) const {
  * \param argc the number of command line arguments
  * \param argv a NULL terminated list with the arguments
  */
-void ImageCommandLineParser::parseArguments(int argc, const char ** argv, bool final) {
+void ImageCommandLineParser::parseArguments(const QStringList& argv, bool final) {
 	settings.in="";
     settings.out="";
 	bool defaultMode=false;
+    int argc = argv.size();
 	for (int i=1; i < argc; ++i) {
         if (i==argc-2 && (argv[i][0] != '-' || argv[i][1] == '\0')) { // the arg before last (in)
-            settings.in = QString::fromLocal8Bit(argv[i]);
+            settings.in = argv[i];
         } else if (i==argc-1 && (argv[i][0] != '-' || argv[i][1] == '\0')) { // the last arg (out)
-            settings.out = QString::fromLocal8Bit(argv[i]);
+            settings.out = argv[i];
 		} else {
-			parseArg(global, argc, argv, defaultMode, i, 0);
+            parseArg(global, argv, defaultMode, i, 0);
 		}
 	}
 

--- a/src/image/imagecommandlineparser.hh
+++ b/src/image/imagecommandlineparser.hh
@@ -54,7 +54,7 @@ public:
 	virtual QString appName() const {return "wkhtmltoimage";}
 
 	//void loadDefaults();
-	void parseArguments(int argc, const char ** argv, bool final=false);
+        void parseArguments(const QStringList &argv, bool final=false);
 
 };
 #endif //__IMAGECOMMANDLINEPARSER_HH__

--- a/src/image/main.cc
+++ b/src/image/main.cc
@@ -1,0 +1,25 @@
+// -*- mode: c++; tab-width: 4; indent-tabs-mode: t; eval: (progn (c-set-style "stroustrup") (c-set-offset 'innamespace 0)); -*-
+// vi:set ts=4 sts=4 sw=4 noet :
+//
+// Copyright 2010, 2011 wkhtmltopdf authors
+//
+// This file is part of wkhtmltopdf.
+//
+// wkhtmltopdf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// wkhtmltopdf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with wkhtmltopdf.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "declarations.hh"
+
+int main(int argc, char * argv[]) {
+    return toimage(argc, argv);
+}

--- a/src/image/wkhtmltoimage.cc
+++ b/src/image/wkhtmltoimage.cc
@@ -25,12 +25,13 @@
 #include <wkhtmltox/imageconverter.hh>
 #include <wkhtmltox/imagesettings.hh>
 #include <wkhtmltox/utilities.hh>
+#include "declarations.hh"
 
 #if defined(Q_OS_UNIX)
 #include <locale.h>
 #endif
 
-int main(int argc, char** argv) {
+int toimage(int argc, char** argv) {
 #if defined(Q_OS_UNIX)
 	setlocale(LC_ALL, "");
 #endif
@@ -38,18 +39,22 @@ int main(int argc, char** argv) {
 	wkhtmltopdf::settings::ImageGlobal settings;
 	//Create a command line parser to parse commandline arguments
 	ImageCommandLineParser parser(settings);
-	//Parse the arguments
-	parser.parseArguments(argc, (const char**)argv);
 
-
-	bool use_graphics=true;
+    bool use_graphics=true;
 #if defined(Q_OS_UNIX) || defined(Q_OS_MAC)
 #ifdef __EXTENSIVE_WKHTMLTOPDF_QT_HACK__
-	use_graphics=settings.useGraphics;
-	if (!use_graphics) QApplication::setGraphicsSystem("raster");
+    use_graphics=settings.useGraphics;
+    if (!use_graphics) QApplication::setGraphicsSystem("raster");
 #endif
 #endif
-	QApplication a(argc, argv, use_graphics);
+    QApplication a(argc, argv, use_graphics);
+    QStringList args = a.arguments();
+    if (args.first().toLower().startsWith("wkhtmltox"))
+        args.removeAt(1);
+
+    //Parse the arguments
+    parser.parseArguments(args);
+
 	MyLooksStyle * style = new MyLooksStyle();
 	a.setStyle(style);
 

--- a/src/image/wkhtmltoimage.cc
+++ b/src/image/wkhtmltoimage.cc
@@ -49,7 +49,7 @@ int toimage(int argc, char** argv) {
 #endif
     QApplication a(argc, argv, use_graphics);
     QStringList args = a.arguments();
-    if (args.first().toLower().startsWith("wkhtmltox"))
+    if (argc > 1 && QRegExp("image|pdf").exactMatch(args.at(1)))
         args.removeAt(1);
 
     //Parse the arguments

--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -357,11 +357,11 @@ CAPI(void) wkhtmltopdf_destroy_global_settings(wkhtmltopdf_global_settings * obj
  *
  * \param settings The settings object to change
  * \param name The name of the setting
- * \param value The new value for the setting
+ * \param value The new value for the setting (UTF-8 encoded)
  * \returns 1 if the setting was updated successfully and 0 otherwise.
  */
 CAPI(int) wkhtmltopdf_set_global_setting(wkhtmltopdf_global_settings * settings, const char * name, const char * value) {
-	return reinterpret_cast<settings::PdfGlobal *>(settings)->set(name, value);
+    return reinterpret_cast<settings::PdfGlobal *>(settings)->set(name, QString::fromUtf8(value));
 }
 
 /**

--- a/src/pdf/main.cc
+++ b/src/pdf/main.cc
@@ -1,0 +1,25 @@
+// -*- mode: c++; tab-width: 4; indent-tabs-mode: t; eval: (progn (c-set-style "stroustrup") (c-set-offset 'innamespace 0)); -*-
+// vi:set ts=4 sts=4 sw=4 noet :
+//
+// Copyright 2010, 2011 wkhtmltopdf authors
+//
+// This file is part of wkhtmltopdf.
+//
+// wkhtmltopdf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// wkhtmltopdf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with wkhtmltopdf.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "declarations.hh"
+
+int main(int argc, char * argv[]) {
+    return topdf(argc, argv);
+}

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -121,7 +121,7 @@ struct OrientationTM: public SomeSetterTM<QPrinter::Orientation> {
 typedef SomeSetter<OrientationTM> OrientationSetter;
 
 struct DefaultTocFunc {
-	bool operator()(const char **, CommandLineParserBase &, char *) {
+    bool operator()(const QStringList&, CommandLineParserBase &, char *) {
 		QFile file;
 		file.open(stdout, QIODevice::WriteOnly | QIODevice::Text);
 		QTextStream stream(&file);
@@ -136,7 +136,7 @@ struct DefaultTocFunc {
   Set the default header
 */
 struct DefaultHeaderFunc {
-	bool operator()(const char **, CommandLineParserBase & p, char * page) {
+    bool operator()(const QStringList&, CommandLineParserBase & p, char * page) {
 		reinterpret_cast<PdfObject*>(page)->header.left="[webpage]";
 		reinterpret_cast<PdfObject*>(page)->header.right="[page]/[topage]";
 		reinterpret_cast<PdfObject*>(page)->header.line=true;
@@ -149,7 +149,7 @@ struct DefaultHeaderFunc {
   Setup default book mode
 */
 struct BookFunc {
-	bool operator()(const char **, CommandLineParserBase &) {
+    bool operator()(const QStringList&, CommandLineParserBase &) {
 		//p.settings.header.left="[section]";
 		//p.settings.header.right="[page]/[toPage]";
 		//p.settings.header.line=true;

--- a/src/pdf/pdfcommandlineparser.cc
+++ b/src/pdf/pdfcommandlineparser.cc
@@ -140,16 +140,17 @@ void PdfCommandLineParser::readme(FILE * fd, bool html) const {
  * \param argc the number of command line arguments
  * \param argv a NULL terminated list with the arguments
  */
-void PdfCommandLineParser::parseArguments(int argc, const char ** argv, bool fromStdin) {
+void PdfCommandLineParser::parseArguments(const QStringList& argv, bool fromStdin) {
 	bool defaultMode = false;
 	int arg=1;
+    int argc = argv.size();
 
 	PdfObject def;
 
 	//Parse global options
 	for (;arg < argc;++arg) {
-		if (argv[arg][0] != '-' || argv[arg][1] == '\0' || defaultMode) break;
-		parseArg(global | page, argc, argv, defaultMode, arg, (char *)&def);
+        if (argv[arg][0] != '-' || argv[arg].size() == 1 || defaultMode) break;
+        parseArg(global | page, argv, defaultMode, arg, (char *)&def);
 	}
 
 	if (readArgsFromStdin && !fromStdin) return;
@@ -159,18 +160,18 @@ void PdfCommandLineParser::parseArguments(int argc, const char ** argv, bool fro
 		pageSettings.push_back(def);
 		PdfObject & ps = pageSettings.back();
 		int sections = page;
-		if (!strcmp(argv[arg],"cover")) {
+        if (argv[arg] == "cover") {
 			++arg;
 			if (arg >= argc-1) {
 				fprintf(stderr, "You need to specify a input file to cover\n\n");
 				usage(stderr, false);
 				exit(1);
 			}
-			ps.page = QString::fromLocal8Bit(argv[arg++]);
+            ps.page = argv[arg++];
 			// parse page options and then override the header/footer settings
 			for (;arg < argc;++arg) {
-				if (argv[arg][0] != '-' || argv[arg][1] == '\0' || defaultMode) break;
-				parseArg(sections, argc, argv, defaultMode, arg, (char*)&ps);
+                if (argv[arg][0] != '-' || argv[arg].size() == 1 || defaultMode) break;
+                parseArg(sections, argv, defaultMode, arg, (char*)&ps);
 			}
 
 			ps.header.left = ps.header.right = ps.header.center = "";
@@ -180,12 +181,12 @@ void PdfCommandLineParser::parseArguments(int argc, const char ** argv, bool fro
 			ps.includeInOutline = false;
 
 			continue;
-		} else if (!strcmp(argv[arg],"toc")) {
+        } else if (argv[arg] == "toc") {
 			++arg;
 			sections = page | toc;
 			ps.isTableOfContent = true;
 		} else {
-			if (!strcmp(argv[arg],"page")) {
+            if (argv[arg] == "page") {
 				++arg;
 				if (arg >= argc-1) {
 					fprintf(stderr, "You need to specify a input file to page\n\n");
@@ -193,13 +194,12 @@ void PdfCommandLineParser::parseArguments(int argc, const char ** argv, bool fro
 					exit(1);
 				}
 			}
-			QByteArray a(argv[arg]);
-			ps.page = QString::fromLocal8Bit(a);
+            ps.page = argv[arg];
 			++arg;
 		}
 		for (;arg < argc;++arg) {
-			if (argv[arg][0] != '-' || argv[arg][1] == '\0' || defaultMode) break;
-			parseArg(sections, argc, argv, defaultMode, arg, (char*)&ps);
+            if (argv[arg][0] != '-' || argv[arg].size() == 1 || defaultMode) break;
+            parseArg(sections, argv, defaultMode, arg, (char*)&ps);
 		}
 	}
 
@@ -208,5 +208,5 @@ void PdfCommandLineParser::parseArguments(int argc, const char ** argv, bool fro
 		usage(stderr, false);
 		exit(1);
 	}
-	globalSettings.out = QString::fromLocal8Bit(argv[argc-1]);
+    globalSettings.out =argv[argc-1];
 }

--- a/src/pdf/pdfcommandlineparser.hh
+++ b/src/pdf/pdfcommandlineparser.hh
@@ -61,7 +61,7 @@ public:
 	virtual void manpage(FILE * fd) const;
 	virtual void readme(FILE * fd, bool html) const;
 
-	void parseArguments(int argc, const char ** argv, bool fromStdin=false);
+        void parseArguments(const QStringList& argv, bool fromStdin=false);
 
 	virtual char * mapAddress(char * d, char * ns) const {
 		const char * _od = reinterpret_cast<const char *>(&od);

--- a/src/pdf/wkhtmltopdf.cc
+++ b/src/pdf/wkhtmltopdf.cc
@@ -142,7 +142,7 @@ int topdf(int argc, char * argv[]) {
 #endif
     QApplication a(argc, argv, use_graphics);
     QStringList args = a.arguments();
-    if (args.first().toLower().startsWith("wkhtmltox"))
+    if (argc > 1 && QRegExp("image|pdf").exactMatch(args.at(1)))
         args.removeAt(1);
 
 	//Parse the arguments

--- a/src/pdf/wkhtmltopdf.cc
+++ b/src/pdf/wkhtmltopdf.cc
@@ -33,6 +33,7 @@
 #include <wkhtmltox/pdfconverter.hh>
 #include <wkhtmltox/pdfsettings.hh>
 #include <wkhtmltox/utilities.hh>
+#include "declarations.hh"
 
 #if defined(Q_OS_UNIX)
 #include <locale.h>
@@ -49,7 +50,7 @@ using namespace wkhtmltopdf;
  * \param nargv on return will hold the arguments read and be NULL terminated
  */
 enum State {skip, tok, q1, q2, q1_esc, q2_esc, tok_esc};
-void parseString(char * buff, int &nargc, char **nargv) {
+void parseString(char * buff, int &nargc, QStringList& nargv) {
 	State state = skip;
 	int write_start=0;
 	int write=0;
@@ -72,7 +73,8 @@ void parseString(char * buff, int &nargc, char **nargv) {
 				next_state=skip;
 				if (write_start != write) {
 					buff[write++]='\0';
-					nargv[nargc++] = buff+write_start;
+                    nargc++;
+                    nargv.append(QString::fromUtf8(buff+write_start));
 					if (nargc > 998) exit(1);
 				}
 				write_start = write;
@@ -111,12 +113,13 @@ void parseString(char * buff, int &nargc, char **nargv) {
 	//Remember the last parameter
 	if (write_start != write) {
 		buff[write++]='\0';
-		nargv[nargc++] = buff+write_start;
-	}
-	nargv[nargc]=NULL;
+        nargc++;
+        nargv.append(QString::fromUtf8(buff+write_start));
+    }
+    nargc = nargv.size();
 }
 
-int main(int argc, char * argv[]) {
+int topdf(int argc, char * argv[]) {
 #if defined(Q_OS_UNIX)
 	setlocale(LC_ALL, "");
 #endif
@@ -129,28 +132,29 @@ int main(int argc, char * argv[]) {
 	//Setup default values in settings
 	//parser.loadDefaults();
 
-	//Parse the arguments
-	parser.parseArguments(argc, (const char**)argv);
-
-	//Construct QApplication required for printing
-	bool use_graphics=true;
+    //Construct QApplication required for printing
+    bool use_graphics=true;
 #if defined(Q_OS_UNIX) || defined(Q_OS_MAC)
 #ifdef __EXTENSIVE_WKHTMLTOPDF_QT_HACK__
-	use_graphics=globalSettings.useGraphics;
-	if (!use_graphics) QApplication::setGraphicsSystem("raster");
+    use_graphics=globalSettings.useGraphics;
+    if (!use_graphics) QApplication::setGraphicsSystem("raster");
 #endif
 #endif
-	QApplication a(argc, argv, use_graphics);
+    QApplication a(argc, argv, use_graphics);
+    QStringList args = a.arguments();
+    if (args.first().toLower().startsWith("wkhtmltox"))
+        args.removeAt(1);
+
+	//Parse the arguments
+    parser.parseArguments(args);
 	MyLooksStyle * style = new MyLooksStyle();
 	a.setStyle(style);
 
 	if (parser.readArgsFromStdin) {
 		char buff[20400];
-		char *nargv[1000];
-		nargv[0] = argv[0];
-		for (int i=0; i < argc; ++i) nargv[i] = argv[i];
+        QStringList nargv = args;
 		while (fgets(buff,20398,stdin)) {
-			int nargc=argc;
+            int nargc=args.size();
 			parseString(buff,nargc,nargv);
 
 			PdfGlobal globalSettings;
@@ -160,7 +164,7 @@ int main(int argc, char * argv[]) {
 			//Setup default values in settings
 			//parser.loadDefaults();
 			//Parse the arguments
-			parser.parseArguments(nargc, (const char**)nargv, true);
+            parser.parseArguments(nargv, true);
 
 			PdfConverter converter(globalSettings);
 			ProgressFeedback feedback(globalSettings.quiet, converter);

--- a/src/shared/arghandler.inl
+++ b/src/shared/arghandler.inl
@@ -22,6 +22,7 @@
 #define __ARGHANDLER_INL__
 #include "commandlineparserbase.hh"
 #include <wkhtmltox/loadsettings.hh>
+#include <QStringList>
 
 template <typename T> class DstArgHandler: public ArgHandler {
 public:
@@ -41,7 +42,7 @@ public:
 	typedef DstArgHandler<T> p_t;
 	const T src;
 	ConstSetter(T & arg, const T s): p_t(arg), src(s) {};
-	bool operator() (const char **, CommandLineParserBase & cp, char * ps) {
+        bool operator() (const QStringList&, CommandLineParserBase & cp, char * ps) {
 		p_t::realDst(cp, ps)=src;
 		return true;
 	}
@@ -81,7 +82,7 @@ struct MapSetter: public DstArgHandler< QList< typename T::T > > {
 		p_t::argn.push_back(keyName);
 		p_t::argn.push_back(valueName);
 	}
-	virtual bool operator() (const char ** args, CommandLineParserBase & cp, char * ps) {
+        virtual bool operator() (const QStringList& args, CommandLineParserBase & cp, char * ps) {
 		p_t::realDst(cp, ps).append( T()(args[0], args[1]) );
 		return true;
 	}
@@ -92,8 +93,8 @@ struct StringListSetter: public DstArgHandler<QList<QString> > {
 	StringListSetter(QList<QString> & a, QString valueName) : p_t (a) {
 		p_t::argn.push_back(valueName);
 	}
-	virtual bool operator() (const char ** args, CommandLineParserBase & cp, char * ps) {
-		p_t::realDst(cp, ps).append( args[0] );
+        virtual bool operator() (const QStringList& args, CommandLineParserBase & cp, char * ps) {
+                p_t::realDst(cp, ps).append( args.at(0) );
 		return true;
 	}
 };
@@ -121,9 +122,9 @@ struct SomeSetter: public DstArgHandler<typename TT::T > {
 		p_t::argn.push_back(an);
 	}
 
-	bool operator() (const char ** vals, CommandLineParserBase & cp, char * ps) {
+        bool operator() (const QStringList& vals, CommandLineParserBase & cp, char * ps) {
 		bool ok;
-		p_t::realDst(cp, ps) = TT::strToT(vals[0], ok);
+                p_t::realDst(cp, ps) = TT::strToT(vals.at(0).toUtf8(), ok);
 		return ok;
 	}
 
@@ -204,7 +205,7 @@ template <typename T> struct Caller: public ArgHandler {
 	Caller(QString a1) {
 		argn.push_back(a1);
 	}
-	bool operator() (const char **vals, CommandLineParserBase & s, char * page) {
+        bool operator() (const QStringList& vals, CommandLineParserBase & s, char * page) {
 		return T()(vals, s, page);
 	}
 };

--- a/src/shared/commandlineparserbase.cc
+++ b/src/shared/commandlineparserbase.cc
@@ -103,33 +103,34 @@ void CommandLineParserBase::license(FILE * fd) const {
 	delete o;
 }
 
-void CommandLineParserBase::parseArg(int sections, const int argc, const char ** argv, bool & defaultMode, int & arg, char * page) {
+void CommandLineParserBase::parseArg(int sections, const QStringList& argv, bool & defaultMode, int & arg, char * page) {
+    int argc = argv.size();
 	if (argv[arg][1] == '-') { //We have a long style argument
 		//After an -- apperas in the argument list all that follows is interpreted as default arguments
-		if (argv[arg][2] == '0') {
+        if (argv[arg].size() == 2) {
 			defaultMode=true;
 			return;
 		}
 		//Try to find a handler for this long switch
-		QHash<QString, ArgHandler*>::iterator j = longToHandler.find(argv[arg]+2);
+        QHash<QString, ArgHandler*>::iterator j = longToHandler.find(argv[arg].mid(2));
 		if (j == longToHandler.end()) { //Ups that argument did not exist
-			fprintf(stderr, "Unknown long argument %s\n\n", argv[arg]);
+            fprintf(stderr, "Unknown long argument %s\n\n", argv[arg].toUtf8());
 			usage(stderr, false);
 			exit(1);
 		}
 		if (!(j.value()->section & sections)) {
-			fprintf(stderr, "%s specified in incorrect location\n\n", argv[arg]);
+            fprintf(stderr, "%s specified in incorrect location\n\n", argv[arg].toUtf8());
 			usage(stderr, false);
 			exit(1);
 		}
 		//Check to see if there is enough arguments to the switch
 		if (argc-arg < j.value()->argn.size()+1) {
-			fprintf(stderr, "Not enough arguments parsed to %s\n\n", argv[arg]);
+            fprintf(stderr, "Not enough arguments parsed to %s\n\n", argv[arg].toUtf8());
 			usage(stderr, false);
 			exit(1);
 		}
-		if (!(*(j.value()))(argv+arg+1, *this, page)) {
-			fprintf(stderr, "Invalid argument(s) parsed to %s\n\n", argv[arg]);
+        if (!(*(j.value()))(argv.mid(arg+1), *this, page)) {
+            fprintf(stderr, "Invalid argument(s) parsed to %s\n\n", argv[arg].toUtf8());
 			usage(stderr, false);
 			exit(1);
 		}
@@ -141,28 +142,28 @@ void CommandLineParserBase::parseArg(int sections, const int argc, const char **
 		arg += j.value()->argn.size();
 	} else {
 		int c=arg;//Remember the current argument we are parsing
-		for (int j=1; argv[c][j] != '\0'; ++j) {
-			QHash<char, ArgHandler*>::iterator k = shortToHandler.find(argv[c][j]);
+        for (int j=1; argv[c].size() > j; ++j) {
+            QHash<char, ArgHandler*>::iterator k = shortToHandler.find(argv[c][j].toLatin1());
 			//If the short argument is invalid print usage information and exit
 			if (k == shortToHandler.end()) {
-				fprintf(stderr, "Unknown switch -%c\n\n", argv[c][j]);
+                fprintf(stderr, "Unknown switch -%c\n\n", argv[c][j].toLatin1());
 				usage(stderr, false);
 				exit(1);
 			}
 
 			if (!(k.value()->section & sections)) {
-				fprintf(stderr, "-%c specified in incorrect location\n\n", argv[c][j]);
+                fprintf(stderr, "-%c specified in incorrect location\n\n", argv[c][j].toLatin1());
 				usage(stderr, false);
 				exit(1);
 			}
 			//Check to see if there is enough arguments to the switch
 			if (argc-arg < k.value()->argn.size()+1) {
-				fprintf(stderr, "Not enough arguments parsed to -%c\n\n", argv[c][j]);
+                fprintf(stderr, "Not enough arguments parsed to -%c\n\n", argv[c][j].toLatin1());
 				usage(stderr, false);
 				exit(1);
 			}
-			if (!(*(k.value()))(argv+arg+1, *this, page)) {
-				fprintf(stderr, "Invalid argument(s) parsed to -%c\n\n", argv[c][j]);
+            if (!(*(k.value()))(argv.mid(arg+1), *this, page)) {
+                fprintf(stderr, "Invalid argument(s) parsed to -%c\n\n", argv[c][j].toLatin1());
 				usage(stderr, false);
 				exit(1);
 			}

--- a/src/shared/commandlineparserbase.cc
+++ b/src/shared/commandlineparserbase.cc
@@ -114,23 +114,23 @@ void CommandLineParserBase::parseArg(int sections, const QStringList& argv, bool
 		//Try to find a handler for this long switch
         QHash<QString, ArgHandler*>::iterator j = longToHandler.find(argv[arg].mid(2));
 		if (j == longToHandler.end()) { //Ups that argument did not exist
-            fprintf(stderr, "Unknown long argument %s\n\n", argv[arg].toUtf8());
+            fprintf(stderr, "Unknown long argument %s\n\n", argv[arg].toUtf8().data());
 			usage(stderr, false);
 			exit(1);
 		}
 		if (!(j.value()->section & sections)) {
-            fprintf(stderr, "%s specified in incorrect location\n\n", argv[arg].toUtf8());
+            fprintf(stderr, "%s specified in incorrect location\n\n", argv[arg].toUtf8().data());
 			usage(stderr, false);
 			exit(1);
 		}
 		//Check to see if there is enough arguments to the switch
 		if (argc-arg < j.value()->argn.size()+1) {
-            fprintf(stderr, "Not enough arguments parsed to %s\n\n", argv[arg].toUtf8());
+            fprintf(stderr, "Not enough arguments parsed to %s\n\n", argv[arg].toUtf8().data());
 			usage(stderr, false);
 			exit(1);
 		}
         if (!(*(j.value()))(argv.mid(arg+1), *this, page)) {
-            fprintf(stderr, "Invalid argument(s) parsed to %s\n\n", argv[arg].toUtf8());
+            fprintf(stderr, "Invalid argument(s) parsed to %s\n\n", argv[arg].toUtf8().data());
 			usage(stderr, false);
 			exit(1);
 		}

--- a/src/shared/commandlineparserbase.hh
+++ b/src/shared/commandlineparserbase.hh
@@ -37,7 +37,7 @@ public:
 	virtual QString getDesc() const;
 	virtual ~ArgHandler();
 	int section;
-	virtual bool operator() (const char ** args, CommandLineParserBase & parser, char * page) = 0;
+        virtual bool operator() (const QStringList& args, CommandLineParserBase & parser, char * page) = 0;
 };
 
 class CommandLineParserBase {
@@ -77,7 +77,7 @@ public:
 	virtual char * mapAddress(char * d, char *) const {return d;}
 	virtual void license(FILE * fd) const;
 	virtual void version(FILE * fd) const;
-	void parseArg(int sections, const int argc, const char ** argv, bool & defaultMode, int & arg, char * page);
+        void parseArg(int sections, const QStringList& argv, bool & defaultMode, int & arg, char * page);
 
 	virtual QString appName() const = 0;
 	const char *appVersion() const;

--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -52,7 +52,7 @@ typedef SomeSetter<ProxyTM> ProxySetter;
 */
 template <bool v>
 struct HelpFunc {
-	bool operator()(const char **, CommandLineParserBase & p, char *) {
+    bool operator()(const QStringList&, CommandLineParserBase & p, char *) {
 		p.usage(stdout,v);
 		exit(0);
 	}
@@ -62,7 +62,7 @@ struct HelpFunc {
   Lambda: Call the man method
 */
 struct ManPageFunc {
-	bool operator()(const char **, CommandLineParserBase & p, char *) {
+    bool operator()(const QStringList&, CommandLineParserBase & p, char *) {
 		p.manpage(stdout);
 		exit(0);
 	}
@@ -73,7 +73,7 @@ struct ManPageFunc {
 */
 template <bool T>
 struct ReadmeFunc {
-	bool operator()(const char **, CommandLineParserBase & p, char *) {
+    bool operator()(const QStringList&, CommandLineParserBase & p, char *) {
 		p.readme(stdout, T);
 		exit(0);
 	}
@@ -83,7 +83,7 @@ struct ReadmeFunc {
   Lambda: Call the version method
 */
 struct VersionFunc {
-	bool operator()(const char **, CommandLineParserBase & p, char *) {
+    bool operator()(const QStringList&, CommandLineParserBase & p, char *) {
 		p.version(stdout);
 		exit(0);
 	}
@@ -93,7 +93,7 @@ struct VersionFunc {
   Lambda: show the license
 */
 struct LicenseFunc {
-    bool operator()(const char **, CommandLineParserBase & p, char *) {
+    bool operator()(const QStringList&, CommandLineParserBase & p, char *) {
 		p.license(stdout);
 		exit(0);
 	}

--- a/src/shared/declarations.hh
+++ b/src/shared/declarations.hh
@@ -1,0 +1,27 @@
+// -*- mode: c++; tab-width: 4; indent-tabs-mode: t; eval: (progn (c-set-style "stroustrup") (c-set-offset 'innamespace 0)); -*-
+// vi:set ts=4 sts=4 sw=4 noet :
+//
+// Copyright 2010, 2011 wkhtmltopdf authors
+//
+// This file is part of wkhtmltopdf.
+//
+// wkhtmltopdf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// wkhtmltopdf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with wkhtmltopdf.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef __DECLARATIONS_HH__
+#define __DECLARATIONS_HH__
+
+int topdf(int argc, char * argv[]);
+int toimage(int argc, char * argv[]);
+
+#endif //__DECLARATIONS_HH__

--- a/src/shared/shared.pri
+++ b/src/shared/shared.pri
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with wkhtmltopdf.  If not, see <http:#www.gnu.org/licenses/>.
 
-HEADERS +=  ../shared/progressfeedback.hh
+HEADERS +=  ../shared/progressfeedback.hh ../shared/declarations.hh
 
 SOURCES += ../shared/outputter.cc ../shared/manoutputter.cc ../shared/htmloutputter.cc \
            ../shared/textoutputter.cc ../shared/arghandler.cc ../shared/commondocparts.cc \

--- a/src/x/wkhtmltox.cc
+++ b/src/x/wkhtmltox.cc
@@ -1,0 +1,34 @@
+// -*- mode: c++; tab-width: 4; indent-tabs-mode: t; eval: (progn (c-set-style "stroustrup") (c-set-offset 'innamespace 0)); -*-
+// vi:set ts=4 sts=4 sw=4 noet :
+//
+// Copyright 2010, 2011 wkhtmltopdf authors
+//
+// This file is part of wkhtmltopdf.
+//
+// wkhtmltopdf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// wkhtmltopdf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with wkhtmltopdf.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "declarations.hh"
+#include <QByteArray>
+#include <stdio.h>
+
+int main(int argc, char * argv[]) {
+    if (argc > 1)
+        if (QByteArray(argv[1]) == "image")
+            return toimage(argc - 1, argv);
+        else if (QByteArray(argv[1]) == "pdf")
+            return topdf(argc - 1, argv);
+
+    fprintf(stderr, "\nUsage:\twkhtmltox image|pdf [params]\n");
+    return 1;
+}

--- a/src/x/wkhtmltox.cc
+++ b/src/x/wkhtmltox.cc
@@ -25,9 +25,9 @@
 int main(int argc, char * argv[]) {
     if (argc > 1)
         if (QByteArray(argv[1]) == "image")
-            return toimage(argc - 1, argv);
+            return toimage(argc, argv);
         else if (QByteArray(argv[1]) == "pdf")
-            return topdf(argc - 1, argv);
+            return topdf(argc, argv);
 
     fprintf(stderr, "\nUsage:\twkhtmltox image|pdf [params]\n");
     return 1;

--- a/src/x/x.pro
+++ b/src/x/x.pro
@@ -18,14 +18,14 @@
 include(../../common.pri)
 
 TEMPLATE = app
-TARGET = wkhtmltopdf
+TARGET = wkhtmltox
 DESTDIR = ../../bin
 DEPENDPATH += . ../shared
 INCLUDEPATH += . ../shared
 
 unix {
     man.path=$$INSTALLBASE/share/man/man1
-    man.extra=LD_LIBRARY_PATH=../../bin/ ../../bin/wkhtmltopdf --manpage | gzip > $(INSTALL_ROOT)/share/man/man1/wkhtmltopdf.1.gz
+    man.extra=LD_LIBRARY_PATH=../../bin/ ../../bin/wkhtmltox --manpage | gzip > $(INSTALL_ROOT)/share/man/man1/wkhtmltox.1.gz
 
     QMAKE_EXTRA_TARGETS += man
     INSTALLS += man
@@ -46,6 +46,11 @@ CONFIG(shared, shared|static) {
   include(../lib/lib.pri)
 }
 
-#Application part
-SOURCES += wkhtmltopdf.cc pdfarguments.cc pdfcommandlineparser.cc \
-           pdfdocparts.cc main.cc
+# pdf
+SOURCES += ../pdf/wkhtmltopdf.cc ../pdf/pdfarguments.cc ../pdf/pdfcommandlineparser.cc \
+           ../pdf/pdfdocparts.cc
+# image
+SOURCES += ../image/wkhtmltoimage.cc ../image/imagearguments.cc ../image/imagecommandlineparser.cc \
+    ../image/imagedocparts.cc
+# x
+SOURCES += wkhtmltox.cc

--- a/wkhtmltopdf.pro
+++ b/wkhtmltopdf.pro
@@ -18,4 +18,4 @@
 TEMPLATE = subdirs
 
 CONFIG += ordered
-SUBDIRS = src/lib src/pdf src/image
+SUBDIRS = src/lib src/pdf src/image src/x


### PR DESCRIPTION
I wrote quite a few bug reports in the last few days. I have not yet thought of a solution of the problem of using the dylib from within a qt 5 app. Therefore I was left with only one option - using QProcess to call a commandline tool to do the conversion. At first I created a tool with qt 5, passing my own arguments and only the ones that my app needs and would use the dylib and do the conversion, but then I thought, I will contribute something small to this project and create this combined image|pdf tool as a part of the wkhtmltopdf project.

So created it and realized commandline arguments in unicode were not accepted. I checked the code and realized the Qt way of handling the arguments was not used - instead C style parsing of argv was going on. I replaced that with handling the QStringList returned from QApplication::arguments(), which is the uniform OS independent way Qt does the arguments - no worrying about utf-8, utf-16 char* and wchar_t* this way.
Now something like this:
wkhtmltopdf уеб.htm адобе.pdf
should work on all supported OS. I tested it on Windows and Mac OS.

The new wkhtmltox tool is very simple - however having it, cuts the space requirements in half, since the old 2 tools are almost identical anyway, but they each include a statically compiled qt, which is 20 MB on Win and 50 MB on Mac.