### PR TITLE
utf-8 parameters fixing

### DIFF
--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -357,11 +357,11 @@ CAPI(void) wkhtmltopdf_destroy_global_settings(wkhtmltopdf_global_settings * obj
  *
  * \param settings The settings object to change
  * \param name The name of the setting
- * \param value The new value for the setting
+ * \param value The new value for the setting (UTF-8 encoded)
  * \returns 1 if the setting was updated successfully and 0 otherwise.
  */
 CAPI(int) wkhtmltopdf_set_global_setting(wkhtmltopdf_global_settings * settings, const char * name, const char * value) {
-	return reinterpret_cast<settings::PdfGlobal *>(settings)->set(name, value);
+	return reinterpret_cast<settings::PdfGlobal *>(settings)->set(name, QString::fromUtf8(value));
 }
 
 /**
@@ -414,11 +414,11 @@ CAPI(void) wkhtmltopdf_destroy_object_settings(wkhtmltopdf_object_settings * obj
  *
  * \param settings The settings object to change
  * \param name The name of the setting
- * \param value The new value for the setting
+ * \param value The new value for the setting (UTF-8 encoded)
  * \returns 1 if the setting was updated successfully and 0 otherwise.
  */
 CAPI(int) wkhtmltopdf_set_object_setting(wkhtmltopdf_object_settings * settings, const char * name, const char * value) {
-	return reinterpret_cast<settings::PdfObject *>(settings)->set(name, value);
+	return reinterpret_cast<settings::PdfObject *>(settings)->set(name, QString::fromUtf8(value));
 }
 
 /**


### PR DESCRIPTION
wkhtmltopdf_set_global_setting and wkhtmltopdf_set_object_setting now accept utf-8 parameters.

[https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2885](see issue 2885)