### PR TITLE
Page Orientation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ gitcontrol.bat
 gitcmd.lnk
 *.tar.bz2
 *.pyc
+*.bak

--- a/include/wkhtmltox/pdfsettings.hh
+++ b/include/wkhtmltox/pdfsettings.hh
@@ -170,6 +170,8 @@ struct DLL_PUBLIC PdfObject {
 
 	QString page;
 
+    //! custom page orientation
+    QString pageSpecificOrientation;
 	//! Header related settings
 	HeaderFooter header;
 

--- a/src/lib/pdfsettings.hh
+++ b/src/lib/pdfsettings.hh
@@ -173,6 +173,8 @@ struct DLL_PUBLIC PdfObject {
 
 	QString page;
 
+//! custom page orientation
+  QString pageSpecificOrientation;
 	//! Header related settings
 	HeaderFooter header;
 

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -227,6 +227,8 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
 
 	section("Page Options");
 	mode(page);
+
+	addarg("page-orientation", NULL, "Set Page orientation to Landscape or Portrait", new QStrSetter(od.pageSpecificOrientation, ""));
  	addarg("default-header",0,"Add a default header, with the name of the page to the left, and the page number to the right, this is short for: --header-left='[webpage]' --header-right='[page]/[toPage]' --top 2cm --header-line", new Caller<DefaultHeaderFunc>());
 
 	addarg("viewport-size", 0, "Set viewport size if you have custom scrollbars or css attribute overflow to emulate window size",new QStrSetter(s.viewportSize,""));


### PR DESCRIPTION
This commit adds the necessary code to allow Portrait and Landscape page
changes within a PDF document.

Implemented a new PDF Object parameter --page-orientation with a value of P for portrait and L for landscape.

Given 3 HTML files where you want First Landscape, Second Portrait and Third Landscape invoke as follows:

wkhtmltopdf.exe part_1.htm --page-orientation L part_2.htm --page-orientation P part_3.htm --page-orientation L Output.pdf
