### PR TITLE
OS X and packaging fixes

### DIFF
--- a/src/image/image.pro
+++ b/src/image/image.pro
@@ -25,7 +25,7 @@ INCLUDEPATH += . ../shared
 
 unix {
     man.path=$$INSTALLBASE/share/man/man1
-    man.extra=LD_LIBRARY_PATH=../../bin/ ../../bin/wkhtmltoimage --manpage | gzip > $(INSTALL_ROOT)/share/man/man1/wkhtmltoimage.1.gz
+    man.extra=LD_LIBRARY_PATH=../../bin/ ../../bin/wkhtmltoimage --manpage | gzip > $(INSTALL_ROOT)$$INSTALLBASE/share/man/man1/wkhtmltoimage.1.gz
 
     QMAKE_EXTRA_TARGETS += man
     INSTALLS += man

--- a/src/image/image.pro
+++ b/src/image/image.pro
@@ -32,6 +32,8 @@ unix {
 }
 
 macx {
+    man.extra=DYLD_LIBRARY_PATH=../../bin/ ../../bin/wkhtmltoimage --manpage | gzip > $(INSTALL_ROOT)$$INSTALLBASE/share/man/man1/wkhtmltoimage.1.gz
+
     CONFIG -= app_bundle
 }
 

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -33,6 +33,10 @@ unix {
    INSTALLS += headers
 }
 
+macx {
+    QMAKE_LFLAGS_SONAME = -Wl,-install_name,$$INSTALLBASE/lib/
+}
+
 windows {
    TARGET_EXT=.dll
 }

--- a/src/pdf/pdf.pro
+++ b/src/pdf/pdf.pro
@@ -25,7 +25,7 @@ INCLUDEPATH += . ../shared
 
 unix {
     man.path=$$INSTALLBASE/share/man/man1
-    man.extra=LD_LIBRARY_PATH=../../bin/ ../../bin/wkhtmltopdf --manpage | gzip > $(INSTALL_ROOT)/share/man/man1/wkhtmltopdf.1.gz
+    man.extra=LD_LIBRARY_PATH=../../bin/ ../../bin/wkhtmltopdf --manpage | gzip > $(INSTALL_ROOT)$$INSTALLBASE/share/man/man1/wkhtmltopdf.1.gz
 
     QMAKE_EXTRA_TARGETS += man
     INSTALLS += man

--- a/src/pdf/pdf.pro
+++ b/src/pdf/pdf.pro
@@ -32,6 +32,8 @@ unix {
 }
 
 macx {
+    man.extra=DYLD_LIBRARY_PATH=../../bin ../../bin/wkhtmltopdf --manpage | gzip > $(INSTALL_ROOT)$$INSTALLBASE/share/man/man1/wkhtmltopdf.1.gz
+
     CONFIG -= app_bundle
 }
 


### PR DESCRIPTION
Here are two commits that fix the build of wkhtmltopdf on OS X and adjust libwkhtmltox' install name to something Mac users would usually expect.

Additionally, one other fix that I think is an oversight with installation prefixes for the manpage and applies to both OS X and other Unixes.
