### PR TITLE
Added support for ssl client certificates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,4 +38,4 @@ Mehdi Abbad
 Lyes Amazouz
 Pascal Bach
 Mário Silva
-JasonParallel
+Jason Smith         <JasonParallel@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -38,3 +38,4 @@ Mehdi Abbad
 Lyes Amazouz
 Pascal Bach
 Mário Silva
+JasonParallel

--- a/include/wkhtmltox/loadsettings.hh
+++ b/include/wkhtmltox/loadsettings.hh
@@ -49,22 +49,7 @@ struct DLL_PUBLIC PostItem {
 struct DLL_PUBLIC LoadGlobal {
 	LoadGlobal();
 	//! Path of the cookie jar file
-	QString cookieJar;
-
-        //! String containing the ssl client cert private key in OpenSSL PEM format
-    	QString clientSslKeyString;
-    
-   	//! Path to the ssl client cert private key in OpenSSL PEM format
-   	QString clientSslKeyPath;
-
-	//! Password to ssl client cert private key
-	QString clientSslKeyPassword;
-    
-	//! String containing the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
-	QString clientSslCrtString;
-
-	//! Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
-	QString clientSslCrtPath;
+        QString cookieJar;
 };
 
 struct DLL_PUBLIC LoadPage {
@@ -81,6 +66,15 @@ struct DLL_PUBLIC LoadPage {
 
 	//! Password used for http auth login
 	QString password;
+
+        //! Path to the ssl client cert private key in OpenSSL PEM format
+        QString clientSslKeyPath;
+
+        //! Password to ssl client cert private key
+        QString clientSslKeyPassword;
+
+        //! Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
+        QString clientSslCrtPath;
 
 	//! How many milliseconds should we wait for a Javascript redirect
 	int jsdelay;

--- a/include/wkhtmltox/loadsettings.hh
+++ b/include/wkhtmltox/loadsettings.hh
@@ -49,7 +49,7 @@ struct DLL_PUBLIC PostItem {
 struct DLL_PUBLIC LoadGlobal {
 	LoadGlobal();
 	//! Path of the cookie jar file
-        QString cookieJar;
+	QString cookieJar;
 };
 
 struct DLL_PUBLIC LoadPage {

--- a/include/wkhtmltox/loadsettings.hh
+++ b/include/wkhtmltox/loadsettings.hh
@@ -50,6 +50,21 @@ struct DLL_PUBLIC LoadGlobal {
 	LoadGlobal();
 	//! Path of the cookie jar file
 	QString cookieJar;
+
+        //! String containing the ssl client cert private key in OpenSSL PEM format
+    	QString clientSslKeyString;
+    
+   	//! Path to the ssl client cert private key in OpenSSL PEM format
+   	QString clientSslKeyPath;
+
+	//! Password to ssl client cert private key
+	QString clientSslKeyPassword;
+    
+	//! String containing the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
+	QString clientSslCrtString;
+
+	//! Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
+	QString clientSslCrtPath;
 };
 
 struct DLL_PUBLIC LoadPage {

--- a/include/wkhtmltox/loadsettings.hh
+++ b/include/wkhtmltox/loadsettings.hh
@@ -67,14 +67,14 @@ struct DLL_PUBLIC LoadPage {
 	//! Password used for http auth login
 	QString password;
 
-        //! Path to the ssl client cert private key in OpenSSL PEM format
-        QString clientSslKeyPath;
+	//! Path to the ssl client cert private key in OpenSSL PEM format
+	QString clientSslKeyPath;
 
-        //! Password to ssl client cert private key
-        QString clientSslKeyPassword;
+	//! Password to ssl client cert private key
+	QString clientSslKeyPassword;
 
-        //! Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
-        QString clientSslCrtPath;
+	//! Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
+	QString clientSslCrtPath;
 
 	//! How many milliseconds should we wait for a Javascript redirect
 	int jsdelay;

--- a/src/lib/loadsettings.hh
+++ b/src/lib/loadsettings.hh
@@ -52,7 +52,7 @@ struct DLL_PUBLIC PostItem {
 struct DLL_PUBLIC LoadGlobal {
 	LoadGlobal();
 	//! Path of the cookie jar file
-    QString cookieJar;
+	QString cookieJar;
 };
 
 struct DLL_PUBLIC LoadPage {

--- a/src/lib/loadsettings.hh
+++ b/src/lib/loadsettings.hh
@@ -53,6 +53,21 @@ struct DLL_PUBLIC LoadGlobal {
 	LoadGlobal();
 	//! Path of the cookie jar file
 	QString cookieJar;
+
+	//! String containing the ssl client cert private key in OpenSSL PEM format
+	QString clientSslKeyString;
+
+	//! Path to the ssl client cert private key in OpenSSL PEM format
+	QString clientSslKeyPath;
+
+	//! Password to ssl client cert private key
+	QString clientSslKeyPassword;
+
+	//! String containing the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
+	QString clientSslCrtString;
+
+	//! Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
+	QString clientSslCrtPath;
 };
 
 struct DLL_PUBLIC LoadPage {

--- a/src/lib/loadsettings.hh
+++ b/src/lib/loadsettings.hh
@@ -70,14 +70,14 @@ struct DLL_PUBLIC LoadPage {
 	//! Password used for http auth login
 	QString password;
 
-    //! Path to the ssl client cert private key in OpenSSL PEM format
-    QString clientSslKeyPath;
+	//! Path to the ssl client cert private key in OpenSSL PEM format
+	QString clientSslKeyPath;
 
-    //! Password to ssl client cert private key
-    QString clientSslKeyPassword;
+	//! Password to ssl client cert private key
+	QString clientSslKeyPassword;
 
-    //! Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
-    QString clientSslCrtPath;
+	//! Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
+	QString clientSslCrtPath;
 
 	//! How many milliseconds should we wait for a Javascript redirect
 	int jsdelay;

--- a/src/lib/loadsettings.hh
+++ b/src/lib/loadsettings.hh
@@ -52,22 +52,7 @@ struct DLL_PUBLIC PostItem {
 struct DLL_PUBLIC LoadGlobal {
 	LoadGlobal();
 	//! Path of the cookie jar file
-	QString cookieJar;
-
-	//! String containing the ssl client cert private key in OpenSSL PEM format
-	QString clientSslKeyString;
-
-	//! Path to the ssl client cert private key in OpenSSL PEM format
-	QString clientSslKeyPath;
-
-	//! Password to ssl client cert private key
-	QString clientSslKeyPassword;
-
-	//! String containing the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
-	QString clientSslCrtString;
-
-	//! Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
-	QString clientSslCrtPath;
+    QString cookieJar;
 };
 
 struct DLL_PUBLIC LoadPage {
@@ -84,6 +69,15 @@ struct DLL_PUBLIC LoadPage {
 
 	//! Password used for http auth login
 	QString password;
+
+    //! Path to the ssl client cert private key in OpenSSL PEM format
+    QString clientSslKeyPath;
+
+    //! Password to ssl client cert private key
+    QString clientSslKeyPassword;
+
+    //! Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
+    QString clientSslCrtPath;
 
 	//! How many milliseconds should we wait for a Javascript redirect
 	int jsdelay;

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -125,10 +125,12 @@ QNetworkReply * MyNetworkAccessManager::createRequest(Operation op, const QNetwo
 				QSslCertificate::fromPath(settings.clientSslCrtPath.toLatin1(),  QSsl::Pem, QRegExp::FixedString);
 			QList<QSslCertificate> cas =  sslConfig.caCertificates();
 			cas.append(chainCerts);
-			sslConfig.setLocalCertificate(chainCerts.first());
-			sslConfig.setCaCertificates(cas);
+			if(!chainCerts.isEmpty()){
+				sslConfig.setLocalCertificate(chainCerts.first());
+				sslConfig.setCaCertificates(cas);
 
-			r3.setSslConfiguration(sslConfig);
+				r3.setSslConfiguration(sslConfig);
+			}
 		}
 	}
 

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -130,7 +130,7 @@ QNetworkReply * MyNetworkAccessManager::createRequest(Operation op, const QNetwo
 
 			r3.setSslConfiguration(sslConfig);
 		}
-    }
+	}
 
 	return QNetworkAccessManager::createRequest(op, r3, outgoingData);
 }

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -26,11 +26,13 @@
 #include <QNetworkDiskCache>
 #include <QTimer>
 #include <QUuid>
-#include <QSslCertificate>
-#include <QSslKey>
 #include <QList>
 #include <QByteArray>
+#if (QT_VERSION >= 0x050000 && !defined QT_NO_SSL) || !defined QT_NO_OPENSSL
+#include <QSslCertificate>
+#include <QSslKey>
 #include <QSslConfiguration>
+#endif
 #if QT_VERSION >= 0x050000
 #include <QUrlQuery>
 #endif
@@ -110,6 +112,7 @@ QNetworkReply * MyNetworkAccessManager::createRequest(Operation op, const QNetwo
 			r3.setRawHeader(j.first.toLatin1(), j.second.toLatin1());
 	}
 
+	#if (QT_VERSION >= 0x050000 && !defined QT_NO_SSL) || !defined QT_NO_OPENSSL
 	if(!settings.clientSslKeyPath.isEmpty() && !settings.clientSslKeyPassword.isEmpty()
 			&& !settings.clientSslCrtPath.isEmpty()){
 		bool success = true;
@@ -133,6 +136,7 @@ QNetworkReply * MyNetworkAccessManager::createRequest(Operation op, const QNetwo
 			}
 		}
 	}
+	#endif
 
 	return QNetworkAccessManager::createRequest(op, r3, outgoingData);
 }

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -110,32 +110,26 @@ QNetworkReply * MyNetworkAccessManager::createRequest(Operation op, const QNetwo
 			r3.setRawHeader(j.first.toLatin1(), j.second.toLatin1());
 	}
 
-    if(settings.clientSslKeyPath != NULL && settings.clientSslKeyPassword != NULL
-            && settings.clientSslCrtPath != NULL){
-        bool success = true;
-        QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
+	if(!settings.clientSslKeyPath.isEmpty() && !settings.clientSslKeyPassword.isEmpty()
+			&& !settings.clientSslCrtPath.isEmpty()){
+		bool success = true;
+		QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
 
-        //key not supplied as string use path
-        QFile keyFile(settings.clientSslKeyPath);
-        success = keyFile.open(QFile::ReadOnly);
-        QSslKey key(&keyFile, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, settings.clientSslKeyPassword.toUtf8());
-        sslConfig.setPrivateKey(key);
-        keyFile.close();
+		QFile keyFile(settings.clientSslKeyPath);
+		if(keyFile.open(QFile::ReadOnly)){
+			QSslKey key(&keyFile, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, settings.clientSslKeyPassword.toUtf8());
+			sslConfig.setPrivateKey(key);
+			keyFile.close();
+			
+			QList<QSslCertificate> chainCerts =
+				QSslCertificate::fromPath(settings.clientSslCrtPath.toLatin1(),  QSsl::Pem, QRegExp::FixedString);
+			QList<QSslCertificate> cas =  sslConfig.caCertificates();
+			cas.append(chainCerts);
+			sslConfig.setLocalCertificate(chainCerts.first());
+			sslConfig.setCaCertificates(cas);
 
-        if(success){
-
-            //key not supplied as string use path
-             QList<QSslCertificate> chainCerts =
-                     QSslCertificate::fromPath(settings.clientSslCrtPath.toLatin1(),  QSsl::Pem, QRegExp::FixedString);
-             QList<QSslCertificate> cas =  sslConfig.caCertificates();
-             cas.append(chainCerts);
-             sslConfig.setLocalCertificate(chainCerts.first());
-             sslConfig.setCaCertificates(cas);
-
-             if(success){
-                 r3.setSslConfiguration(sslConfig);
-             }
-        }
+			r3.setSslConfiguration(sslConfig);
+		}
     }
 
 	return QNetworkAccessManager::createRequest(op, r3, outgoingData);

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -131,7 +131,6 @@ PdfConverterPrivate::PdfConverterPrivate(PdfGlobal & s, PdfConverter & o) :
 		int height = viewportSizeList.last().toInt();
 		viewportSize = QSize(width,height);
 	}
-
 }
 
 PdfConverterPrivate::~PdfConverterPrivate() {

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -132,7 +132,6 @@ PdfConverterPrivate::PdfConverterPrivate(PdfGlobal & s, PdfConverter & o) :
 		viewportSize = QSize(width,height);
 	}
 
-
 }
 
 PdfConverterPrivate::~PdfConverterPrivate() {

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -31,11 +31,6 @@
 #include <QWebPage>
 #include <QWebSettings>
 #include <QXmlQuery>
-#include <QSslCertificate>
-#include <QSslKey>
-#include <QList>
-#include <QByteArray>
-#include <QSslConfiguration>
 #include <algorithm>
 #include <qapplication.h>
 #include <qfileinfo.h>
@@ -50,7 +45,6 @@ using namespace wkhtmltopdf::settings;
 
 #define STRINGIZE_(x) #x
 #define STRINGIZE(x) STRINGIZE_(x)
-#define S(t) ((t).toLocal8Bit().constData())
 
 const qreal PdfConverter::millimeterToPointMultiplier = 2.83464567;
 
@@ -138,51 +132,7 @@ PdfConverterPrivate::PdfConverterPrivate(PdfGlobal & s, PdfConverter & o) :
 		viewportSize = QSize(width,height);
 	}
 
-    if(settings.load.clientSslKeyString != NULL || settings.load.clientSslKeyPath != NULL){
-        bool success = true;
-        QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
-        if(settings.load.clientSslKeyPassword == NULL){
-            fprintf(stderr, "Client ssl key can not be loaded without password. Skipping ssl config.");
-        }else if(settings.load.clientSslKeyString != NULL){
-            QSslKey key(settings.load.clientSslKeyString.toUtf8(), QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, settings.load.clientSslKeyPassword.toUtf8());
-             sslConfig.setPrivateKey(key);
-        }else{
-            //key not supplied as string use path
-            QFile keyFile(settings.load.clientSslKeyPath);
-            success = keyFile.open(QFile::ReadOnly);
-            if(!success){
-                 fprintf(stderr, "Client ssl key file coult not be loaded. Skipping ssl config.");
-            }
-            QSslKey key(&keyFile, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, settings.load.clientSslKeyPassword.toUtf8());
-            sslConfig.setPrivateKey(key);
-            keyFile.close();
-        }
-        if(success){
-             if(settings.load.clientSslCrtString == NULL && settings.load.clientSslCrtPath == NULL){
-                 success = false;
-                 fprintf(stderr, "Client ssl cert is required when a ssl client key has been supplied. Skipping ssl config.");
-             }else if(settings.load.clientSslCrtString != NULL){
-                 QList<QSslCertificate> chainCerts =
-                         QSslCertificate::fromData(settings.load.clientSslCrtString.toUtf8(), QSsl::Pem);
-                 QList<QSslCertificate> cas =  sslConfig.caCertificates();
-                 cas.append(chainCerts);
-                 sslConfig.setLocalCertificate(chainCerts.first());
-                 sslConfig.setCaCertificates(cas);
-             }else{
-                //key not supplied as string use path
-                 QList<QSslCertificate> chainCerts =
-                         QSslCertificate::fromPath(settings.load.clientSslCrtPath.toLatin1(),  QSsl::Pem, QRegExp::FixedString);
-                 QList<QSslCertificate> cas =  sslConfig.caCertificates();
-                 cas.append(chainCerts);
-                 sslConfig.setLocalCertificate(chainCerts.first());
-                 sslConfig.setCaCertificates(cas);
-             }
 
-             if(success){
-                 QSslConfiguration::setDefaultConfiguration(sslConfig);
-             }
-        }
-    }
 }
 
 PdfConverterPrivate::~PdfConverterPrivate() {

--- a/src/lib/reflect.cc
+++ b/src/lib/reflect.cc
@@ -51,15 +51,15 @@ ReflectClass::~ReflectClass() {
 }
 
 ReflectImpl<LoadGlobal>::ReflectImpl(LoadGlobal & c) {
-    WKHTMLTOPDF_REFLECT(cookieJar);
+	WKHTMLTOPDF_REFLECT(cookieJar);
 }
 
 ReflectImpl<LoadPage>::ReflectImpl(LoadPage & c) {
 	WKHTMLTOPDF_REFLECT(username);
 	WKHTMLTOPDF_REFLECT(password);
-    WKHTMLTOPDF_REFLECT(clientSslKeyPath);
-    WKHTMLTOPDF_REFLECT(clientSslKeyPassword);
-    WKHTMLTOPDF_REFLECT(clientSslCrtPath);
+	WKHTMLTOPDF_REFLECT(clientSslKeyPath);
+	WKHTMLTOPDF_REFLECT(clientSslKeyPassword);
+	WKHTMLTOPDF_REFLECT(clientSslCrtPath);
 	WKHTMLTOPDF_REFLECT(jsdelay);
 	WKHTMLTOPDF_REFLECT(windowStatus);
 	WKHTMLTOPDF_REFLECT(zoomFactor);

--- a/src/lib/reflect.cc
+++ b/src/lib/reflect.cc
@@ -52,6 +52,11 @@ ReflectClass::~ReflectClass() {
 
 ReflectImpl<LoadGlobal>::ReflectImpl(LoadGlobal & c) {
 	WKHTMLTOPDF_REFLECT(cookieJar);
+	WKHTMLTOPDF_REFLECT(clientSslKeyString);
+	WKHTMLTOPDF_REFLECT(clientSslKeyPath);
+	WKHTMLTOPDF_REFLECT(clientSslKeyPassword);
+	WKHTMLTOPDF_REFLECT(clientSslCrtString);
+	WKHTMLTOPDF_REFLECT(clientSslCrtPath);
 }
 
 ReflectImpl<LoadPage>::ReflectImpl(LoadPage & c) {

--- a/src/lib/reflect.cc
+++ b/src/lib/reflect.cc
@@ -51,17 +51,15 @@ ReflectClass::~ReflectClass() {
 }
 
 ReflectImpl<LoadGlobal>::ReflectImpl(LoadGlobal & c) {
-	WKHTMLTOPDF_REFLECT(cookieJar);
-	WKHTMLTOPDF_REFLECT(clientSslKeyString);
-	WKHTMLTOPDF_REFLECT(clientSslKeyPath);
-	WKHTMLTOPDF_REFLECT(clientSslKeyPassword);
-	WKHTMLTOPDF_REFLECT(clientSslCrtString);
-	WKHTMLTOPDF_REFLECT(clientSslCrtPath);
+    WKHTMLTOPDF_REFLECT(cookieJar);
 }
 
 ReflectImpl<LoadPage>::ReflectImpl(LoadPage & c) {
 	WKHTMLTOPDF_REFLECT(username);
 	WKHTMLTOPDF_REFLECT(password);
+    WKHTMLTOPDF_REFLECT(clientSslKeyPath);
+    WKHTMLTOPDF_REFLECT(clientSslKeyPassword);
+    WKHTMLTOPDF_REFLECT(clientSslCrtPath);
 	WKHTMLTOPDF_REFLECT(jsdelay);
 	WKHTMLTOPDF_REFLECT(windowStatus);
 	WKHTMLTOPDF_REFLECT(zoomFactor);

--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -174,6 +174,11 @@ void CommandLineParserBase::addGlobalLoadArgs(LoadGlobal & s) {
 	qthack(false);
 
     addarg("cookie-jar", 0, "Read and write cookies from and to the supplied cookie jar file", new QStrSetter(s.cookieJar, "path") );
+    addarg("ssl-key-string",0,"String containing the ssl client cert private key in OpenSSL PEM format", new QStrSetter(s.clientSslKeyString, "PEM String"));
+    addarg("ssl-key-path",0,"Path to ssl client cert private key in OpenSSL PEM format", new QStrSetter(s.clientSslKeyPath, "path"));
+    addarg("ssl-key-password",0,"Password to ssl client cert private key", new QStrSetter(s.clientSslKeyPassword, "password"));
+    addarg("ssl-crt-string",0,"String containing the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs", new QStrSetter(s.clientSslCrtString, "PEM String"));
+    addarg("ssl-crt-path",0,"Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs", new QStrSetter(s.clientSslCrtPath, "path"));
 }
 
 void CommandLineParserBase::addWebArgs(Web & s) {

--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -206,9 +206,9 @@ void CommandLineParserBase::addPageLoadArgs(LoadPage & s) {
 	addarg("bypass-proxy-for", 0, "Bypass proxy for host (repeatable)", new StringListSetter(s.bypassProxyForHosts, "value"));
 	addarg("username",0,"HTTP Authentication username", new QStrSetter(s.username, "username"));
 	addarg("password",0,"HTTP Authentication password", new QStrSetter(s.password, "password"));
-    addarg("ssl-key-path",0,"Path to ssl client cert private key in OpenSSL PEM format", new QStrSetter(s.clientSslKeyPath, "path"));
-    addarg("ssl-key-password",0,"Password to ssl client cert private key", new QStrSetter(s.clientSslKeyPassword, "password"));
-    addarg("ssl-crt-path",0,"Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs", new QStrSetter(s.clientSslCrtPath, "path"));
+	addarg("ssl-key-path",0,"Path to ssl client cert private key in OpenSSL PEM format", new QStrSetter(s.clientSslKeyPath, "path"));
+	addarg("ssl-key-password",0,"Password to ssl client cert private key", new QStrSetter(s.clientSslKeyPassword, "password"));
+	addarg("ssl-crt-path",0,"Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs", new QStrSetter(s.clientSslCrtPath, "path"));
 	addarg("load-error-handling", 0, "Specify how to handle pages that fail to load: abort, ignore or skip", new LoadErrorHandlingSetting(s.loadErrorHandling, "handler"));
 	addarg("load-media-error-handling", 0, "Specify how to handle media files that fail to load: abort, ignore or skip", new LoadErrorHandlingSetting(s.mediaLoadErrorHandling, "handler"));
 	addarg("custom-header",0,"Set an additional HTTP header (repeatable)", new MapSetter<>(s.customHeaders, "name", "value"));

--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -174,11 +174,6 @@ void CommandLineParserBase::addGlobalLoadArgs(LoadGlobal & s) {
 	qthack(false);
 
     addarg("cookie-jar", 0, "Read and write cookies from and to the supplied cookie jar file", new QStrSetter(s.cookieJar, "path") );
-    addarg("ssl-key-string",0,"String containing the ssl client cert private key in OpenSSL PEM format", new QStrSetter(s.clientSslKeyString, "PEM String"));
-    addarg("ssl-key-path",0,"Path to ssl client cert private key in OpenSSL PEM format", new QStrSetter(s.clientSslKeyPath, "path"));
-    addarg("ssl-key-password",0,"Password to ssl client cert private key", new QStrSetter(s.clientSslKeyPassword, "password"));
-    addarg("ssl-crt-string",0,"String containing the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs", new QStrSetter(s.clientSslCrtString, "PEM String"));
-    addarg("ssl-crt-path",0,"Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs", new QStrSetter(s.clientSslCrtPath, "path"));
 }
 
 void CommandLineParserBase::addWebArgs(Web & s) {
@@ -211,6 +206,9 @@ void CommandLineParserBase::addPageLoadArgs(LoadPage & s) {
 	addarg("bypass-proxy-for", 0, "Bypass proxy for host (repeatable)", new StringListSetter(s.bypassProxyForHosts, "value"));
 	addarg("username",0,"HTTP Authentication username", new QStrSetter(s.username, "username"));
 	addarg("password",0,"HTTP Authentication password", new QStrSetter(s.password, "password"));
+    addarg("ssl-key-path",0,"Path to ssl client cert private key in OpenSSL PEM format", new QStrSetter(s.clientSslKeyPath, "path"));
+    addarg("ssl-key-password",0,"Password to ssl client cert private key", new QStrSetter(s.clientSslKeyPassword, "password"));
+    addarg("ssl-crt-path",0,"Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs", new QStrSetter(s.clientSslCrtPath, "path"));
 	addarg("load-error-handling", 0, "Specify how to handle pages that fail to load: abort, ignore or skip", new LoadErrorHandlingSetting(s.loadErrorHandling, "handler"));
 	addarg("load-media-error-handling", 0, "Specify how to handle media files that fail to load: abort, ignore or skip", new LoadErrorHandlingSetting(s.mediaLoadErrorHandling, "handler"));
 	addarg("custom-header",0,"Set an additional HTTP header (repeatable)", new MapSetter<>(s.customHeaders, "name", "value"));


### PR DESCRIPTION
This adds support for using client certificates for https connections to servers. The private key and public key should be in PEM format. The path to the certificate files or the PEM encoded certificate can be passed as parameters along with the password for the private key. Optionally the client cert public key file can contain the PEM encoded cert public keys for it's certificate chain appended to the end of the file. 

This is a fix for issue #3090