### PR TITLE
Send cookies one time

### DIFF
--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -451,6 +451,7 @@ void ResourceObject::load() {
 	}
 
 
+	multiPageLoader.cookieJar->clearExtraCookies();
 	typedef QPair<QString, QString> SSP;
  	foreach (const SSP & pair, settings.cookies)
 		multiPageLoader.cookieJar->useCookie(url, pair.first, pair.second);
@@ -467,6 +468,10 @@ void ResourceObject::load() {
 			r.setHeader(QNetworkRequest::ContentTypeHeader, QString("multipart/form-data, boundary=")+boundary);
 		webPage.mainFrame()->load(r, QNetworkAccessManager::PostOperation, postData);
 	}
+}
+
+void MyCookieJar::clearExtraCookies() {
+	extraCookies.clear();	
 }
 
 void MyCookieJar::useCookie(const QUrl &, const QString & name, const QString & value) {

--- a/src/lib/multipageloader_p.hh
+++ b/src/lib/multipageloader_p.hh
@@ -112,6 +112,7 @@ class DLL_LOCAL MyCookieJar: public QNetworkCookieJar {
 private:
 	QList<QNetworkCookie> extraCookies;
 public:
+	void clearExtraCookies();
 	void useCookie(const QUrl & url, const QString & name, const QString & value);
 	QList<QNetworkCookie> cookiesForUrl(const QUrl & url) const;
 	void loadFromFile(const QString & path);


### PR DESCRIPTION
MyCookieJar's extra cookies are not associated with an explicit url, as
they probably should be. Therefore, the cookies need to be cleared
before loading more cookies or we'll have all cookies for all urls sent,
which is redundent.