### PR TITLE
Added missing PDF global setting

### DIFF
--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -118,6 +118,7 @@ struct DLL_LOCAL ReflectImpl<PdfGlobal>: public ReflectClass {
 		WKHTMLTOPDF_REFLECT(copies);
 		WKHTMLTOPDF_REFLECT(collate);
 		WKHTMLTOPDF_REFLECT(outline);
+		WKHTMLTOPDF_REFLECT(outlineDepth);
 		WKHTMLTOPDF_REFLECT(dumpOutline);
 		WKHTMLTOPDF_REFLECT(out);
 		WKHTMLTOPDF_REFLECT(documentTitle);


### PR DESCRIPTION
The [c-bindings](http://wkhtmltopdf.org/libwkhtmltox/pagesettings.html#pagePdfGlobal) page states that there is a `outlineDepth` property accessible for the global settings object.

Trying to get or set the setting via `wkhtmltopdf_get_global_setting` or `wkhtmltopdf_set_global_setting` will not work as the `WKHTMLTOPDF_REFLECT` part is missing for the `outlineDepth` field.