### PR TITLE
Fixed code part that made no sense in reflect.hh

### DIFF
--- a/src/lib/reflect.hh
+++ b/src/lib/reflect.hh
@@ -75,7 +75,10 @@ struct DLL_LOCAL ReflectImpl<bool>: public ReflectSimple {
 	void set(const QString & value, bool * ok) {
 		if (value == "true") b=true;
 		else if (value == "false") b=false;
-		else *ok=false;
+		else {
+			*ok=false;
+			return;
+		}
 		*ok=true;
 	}
 };


### PR DESCRIPTION
The reflection setter for boolean values will always return `ok = true` even if the string value is not a correct boolean ([source](https://github.com/wkhtmltopdf/wkhtmltopdf/blob/master/src/lib/reflect.hh#L76-L79)):

```
void set(const QString & value, bool * ok) {
    if (value == "true") b=true;           // 1
    else if (value == "false") b=false;    // 2
    else *ok=false;                        // 3
    *ok=true;                              // 4
}
```


The `else` in line # 3 will set the `ok` value to `false` if `value` is not a correct boolean but on the next line (# 4) `ok` will be set to `true` regardless.