### PR TITLE
Deinit never returns `false`

### DIFF
--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -321,6 +321,7 @@ CAPI(int) wkhtmltopdf_init(int use_graphics) {
  * \sa wkhtmltopdf_init
  */
 CAPI(int) wkhtmltopdf_deinit() {
+	if (usage == 0) return 0;
 	--usage;
 	if (usage != 0) return 1;
 	if (a != 0) delete a;


### PR DESCRIPTION
`wkhtmltopdf_deinit` never returns `false` and the `usage` variable could go below `0` if there are more calls to `wkhtmltopdf_deinit` than to `wkhtmltopdf_init`.

Fixed the problem by adding a check for `usage == 0` at the beginning of the method. If the usage is `0` the method will return `false` instead of `true`.