### PR TITLE
Added error message for network errors related to non-media files

### DIFF
--- a/include/wkhtmltox/imagesettings.hh
+++ b/include/wkhtmltox/imagesettings.hh
@@ -57,8 +57,8 @@ struct DLL_PUBLIC ImageGlobal {
 	LoadPage loadPage;
 	Web web;
 
-	//! Be less verbose
-	bool quiet;
+	//! Verbosity level (0=quiet; 1=standard; 2=verbose)
+	int verbosity;
 
 	bool transparent;
 

--- a/include/wkhtmltox/pdfsettings.hh
+++ b/include/wkhtmltox/pdfsettings.hh
@@ -82,8 +82,8 @@ struct DLL_PUBLIC PdfGlobal {
 	//! Size related settings
 	Size size;
 
-	//! Be less verbose
-	bool quiet;
+	//! Verbosity level (0=quiet; 1=standard; 2=verbose)
+	int verbosity;
 
 	//! Should we use the graphics system
 	bool useGraphics;

--- a/src/image/imagearguments.cc
+++ b/src/image/imagearguments.cc
@@ -31,7 +31,7 @@ ImageCommandLineParser::ImageCommandLineParser(wkhtmltopdf::settings::ImageGloba
 
 	extended(false);
 	qthack(false);
-	addarg("quiet", 'q', "Be less verbose", new ConstSetter<bool>(s.quiet,true));
+	addarg("verbosity", 'v', "Verbosity level from 0 (quiet) to 2 (extra verbose)", new IntSetter(s.verbosity, "number"));
 	addarg("width",0,"Set screen width, note that this is used only as a guide line. Use --disable-smart-width to make it strict.", new IntSetter(s.screenWidth,"int"));
 	addarg("height",0,"Set screen height (default is calculated from page content)", new IntSetter(s.screenHeight, "int"));
 	// addarg("scale-w",0,"Set width for resizing", new IntSetter(s.scale.width,"int"));

--- a/src/image/wkhtmltoimage.cc
+++ b/src/image/wkhtmltoimage.cc
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
 	QObject::connect(&converter, SIGNAL(radiobuttonSvgChanged(const QString &)), style, SLOT(setRadioButtonSvg(const QString &)));
 	QObject::connect(&converter, SIGNAL(radiobuttonCheckedSvgChanged(const QString &)), style, SLOT(setRadioButtonCheckedSvg(const QString &)));
 
-	wkhtmltopdf::ProgressFeedback feedback(settings.quiet, converter);
+	wkhtmltopdf::ProgressFeedback feedback(settings.verbosity, converter);
 	bool success = converter.convert();
 	return handleError(success, converter.httpErrorCode());
 }

--- a/src/lib/imagesettings.cc
+++ b/src/lib/imagesettings.cc
@@ -41,7 +41,7 @@ struct DLL_LOCAL ReflectImpl<ImageGlobal>: public ReflectClass {
 	ReflectImpl(ImageGlobal & c) {
 		WKHTMLTOPDF_REFLECT(screenWidth);
 		WKHTMLTOPDF_REFLECT(screenHeight);
-		WKHTMLTOPDF_REFLECT(quiet);
+		WKHTMLTOPDF_REFLECT(verbosity);
 		WKHTMLTOPDF_REFLECT(transparent);
 		WKHTMLTOPDF_REFLECT(useGraphics);
 		WKHTMLTOPDF_REFLECT(in);
@@ -60,7 +60,7 @@ CropSettings::CropSettings():
 	height(-1) {}
 
 ImageGlobal::ImageGlobal():
-	quiet(false),
+	verbosity(1),
 	transparent(false),
 	useGraphics(false),
 	in(""),

--- a/src/lib/imagesettings.hh
+++ b/src/lib/imagesettings.hh
@@ -60,8 +60,8 @@ struct DLL_PUBLIC ImageGlobal {
 	LoadPage loadPage;
 	Web web;
 
-	//! Be less verbose
-	bool quiet;
+	//! Verbosity level (0=quiet; 1=standard; 2=verbose)
+	int verbosity;
 
 	bool transparent;
 

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -220,6 +220,9 @@ ResourceObject::ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, con
 	connect(&networkAccessManager, SIGNAL(warning(const QString &)),
 			this, SLOT(warning(const QString &)));
 
+	connect(&networkAccessManager, SIGNAL(error(const QString &)),
+			this, SLOT(error(const QString &)));
+
 	networkAccessManager.setCookieJar(multiPageLoader.cookieJar);
 
 	//If we must use a proxy, create a host of objects
@@ -403,6 +406,8 @@ void ResourceObject::amfinished(QNetworkReply * reply) {
 			//      no HTTP access at all, so we want network errors to be reported
 			//      with a higher priority than HTTP ones.
 			//      See: http://doc-snapshot.qt-project.org/4.8/qnetworkreply.html#NetworkError-enum
+			error(QString("Failed to load %1, with network status code %2 and http status code %3")
+				.arg(reply->url().toString()).arg(networkStatus).arg(httpStatus));
 			httpErrorCode = networkStatus > 0 ? (networkStatus + 1000) : httpStatus;
 			return;
 		}

--- a/src/lib/multipageloader_p.hh
+++ b/src/lib/multipageloader_p.hh
@@ -58,6 +58,7 @@ public:
 	QNetworkReply * createRequest(Operation op, const QNetworkRequest & req, QIODevice * outgoingData = 0);
 signals:
 	void warning(const QString & text);
+	void error(const QString & text);
 };
 
 class DLL_LOCAL MultiPageLoaderPrivate;

--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -107,7 +107,7 @@ template<>
 struct DLL_LOCAL ReflectImpl<PdfGlobal>: public ReflectClass {
 	ReflectImpl(PdfGlobal & c) {
 		WKHTMLTOPDF_REFLECT(size);
-		WKHTMLTOPDF_REFLECT(quiet);
+		WKHTMLTOPDF_REFLECT(verbosity);
 		WKHTMLTOPDF_REFLECT(useGraphics);
 		WKHTMLTOPDF_REFLECT(resolveRelativeLinks);
 		WKHTMLTOPDF_REFLECT(orientation);
@@ -368,7 +368,7 @@ Margin::Margin():
 	left(UnitReal(10,QPrinter::Millimeter)) {}
 
 PdfGlobal::PdfGlobal():
-	quiet(false),
+	verbosity(1),
 	useGraphics(false),
 	resolveRelativeLinks(true),
 	orientation(QPrinter::Portrait),

--- a/src/lib/pdfsettings.hh
+++ b/src/lib/pdfsettings.hh
@@ -85,8 +85,8 @@ struct DLL_PUBLIC PdfGlobal {
 	//! Size related settings
 	Size size;
 
-	//! Be less verbose
-	bool quiet;
+	//! Verbosity level (0=quiet; 1=standard; 2=verbose)
+	int verbosity;
 
 	//! Should we use the graphics system
 	bool useGraphics;

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -176,7 +176,7 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
 	extended(false);
 	qthack(false);
 
-	addarg("quiet", 'q', "Be less verbose", new ConstSetter<bool>(s.quiet,true));
+	addarg("verbosity", 'v', "Verbosity level from 0 (quiet) to 2 (extra verbose)", new IntSetter(s.verbosity, "number"));
 
 	addarg("no-collate", 0, "Do not collate when printing multiple copies", new ConstSetter<bool>(s.collate, false));
 	addarg("collate", 0, "Collate when printing multiple copies", new ConstSetter<bool>(s.collate, true));

--- a/src/pdf/wkhtmltopdf.cc
+++ b/src/pdf/wkhtmltopdf.cc
@@ -208,7 +208,7 @@ int main(int argc, char * argv[]) {
 			parser.parseArguments(nargc, (const char**)nargv, true);
 
 			PdfConverter converter(globalSettings);
-			ProgressFeedback feedback(globalSettings.quiet, converter);
+			ProgressFeedback feedback(globalSettings.verbosity, converter);
 			foreach (const PdfObject & object, objectSettings)
 				converter.addResource(object);
 
@@ -227,7 +227,7 @@ int main(int argc, char * argv[]) {
 	QObject::connect(&converter, SIGNAL(radiobuttonSvgChanged(const QString &)), style, SLOT(setRadioButtonSvg(const QString &)));
 	QObject::connect(&converter, SIGNAL(radiobuttonCheckedSvgChanged(const QString &)), style, SLOT(setRadioButtonCheckedSvg(const QString &)));
 
-	ProgressFeedback feedback(globalSettings.quiet, converter);
+	ProgressFeedback feedback(globalSettings.verbosity, converter);
 	foreach (const PdfObject & object, objectSettings)
 		converter.addResource(object);
 

--- a/src/shared/progressfeedback.cc
+++ b/src/shared/progressfeedback.cc
@@ -38,7 +38,7 @@ namespace wkhtmltopdf {
   \param message The warning message
 */
 void ProgressFeedback::warning(const QString &message) {
-	if (quiet) return;
+	if (verbosity < 2) return;
 	fprintf(stderr, "Warning: %s",S(message));
 	for (int l = 9 + message.size(); l < lw; ++l)
 		fprintf(stderr, " ");
@@ -62,7 +62,7 @@ void ProgressFeedback::error(const QString &message) {
   \brief Write out the name of the next phase
 */
 void ProgressFeedback::phaseChanged() {
-	if (quiet) return;
+	if (verbosity < 1) return;
 	QString desc=converter.phaseDescription();
 	fprintf(stderr, "%s", S(desc));
 
@@ -79,7 +79,7 @@ void ProgressFeedback::phaseChanged() {
   \brief Update progress bar
 */
 void ProgressFeedback::progressChanged(int progress) {
-	if (quiet) return;
+	if (verbosity < 1) return;
 	fprintf(stderr, "[");
 	int w=60;
 	progress *= w;
@@ -97,8 +97,8 @@ void ProgressFeedback::progressChanged(int progress) {
 	fprintf(stderr, "\r");
 }
 
-ProgressFeedback::ProgressFeedback(bool q, Converter & _):
-    quiet(q), converter(_), lw(0) {
+ProgressFeedback::ProgressFeedback(int v, Converter & _):
+    verbosity(v), converter(_), lw(0) {
     connect(&converter, SIGNAL(warning(const QString &)), this, SLOT(warning(const QString &)));
 	connect(&converter, SIGNAL(error(const QString &)), this, SLOT(error(const QString &)));
 	connect(&converter, SIGNAL(phaseChanged()), this, SLOT(phaseChanged()));

--- a/src/shared/progressfeedback.hh
+++ b/src/shared/progressfeedback.hh
@@ -26,7 +26,7 @@ namespace wkhtmltopdf {
 class ProgressFeedback: public QObject {
 	Q_OBJECT
 private:
-	bool quiet;
+	int verbosity;
 	Converter & converter;
 	int lw;
 public slots:
@@ -35,7 +35,7 @@ public slots:
 	void phaseChanged();
 	void progressChanged(int progress);
 public:
-	ProgressFeedback(bool quiet, Converter & _);
+	ProgressFeedback(int verbosity, Converter & _);
 };
 
 }


### PR DESCRIPTION
If a network error occurs and the URL is not detected as media file, the converter exits with exit code 1 but no errors are logged, which makes debugging difficult. This PR adds an error message to that case.

Additionally, the logging output has been improved by switching from a quiet/verbose logging scheme to a levelled-logging scheme (see new commandline option 'verbosity').