### PR TITLE
Added error message for network errors related to non-media files

### DIFF
--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -220,6 +220,9 @@ ResourceObject::ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, con
 	connect(&networkAccessManager, SIGNAL(warning(const QString &)),
 			this, SLOT(warning(const QString &)));
 
+	connect(&networkAccessManager, SIGNAL(error(const QString &)),
+			this, SLOT(error(const QString &)));
+
 	networkAccessManager.setCookieJar(multiPageLoader.cookieJar);
 
 	//If we must use a proxy, create a host of objects
@@ -403,6 +406,8 @@ void ResourceObject::amfinished(QNetworkReply * reply) {
 			//      no HTTP access at all, so we want network errors to be reported
 			//      with a higher priority than HTTP ones.
 			//      See: http://doc-snapshot.qt-project.org/4.8/qnetworkreply.html#NetworkError-enum
+			error(QString("Failed to load %1, with network status code %2 and http status code %3")
+				.arg(reply->url().toString()).arg(networkStatus).arg(httpStatus));
 			httpErrorCode = networkStatus > 0 ? (networkStatus + 1000) : httpStatus;
 			return;
 		}

--- a/src/lib/multipageloader_p.hh
+++ b/src/lib/multipageloader_p.hh
@@ -58,6 +58,7 @@ public:
 	QNetworkReply * createRequest(Operation op, const QNetworkRequest & req, QIODevice * outgoingData = 0);
 signals:
 	void warning(const QString & text);
+	void error(const QString & text);
 };
 
 class DLL_LOCAL MultiPageLoaderPrivate;


### PR DESCRIPTION
If a network error occurs and the URL is not detected as media file, the converter exits with exit code 1 but no errors are logged, which makes debugging difficult. This PR adds an error message to that case.