### PR TITLE
New commandline option 'verbosity' to allow different log levels

### DIFF
--- a/include/wkhtmltox/converter.hh
+++ b/include/wkhtmltox/converter.hh
@@ -32,7 +32,7 @@ public:
 	virtual ~Converter() {};
 
     int currentPhase();
-	int phaseCount();
+    int phaseCount();
     QString phaseDescription(int phase=-1);
     QString progressString();
     int httpErrorCode();

--- a/include/wkhtmltox/imagesettings.hh
+++ b/include/wkhtmltox/imagesettings.hh
@@ -57,8 +57,8 @@ struct DLL_PUBLIC ImageGlobal {
 	LoadPage loadPage;
 	Web web;
 
-	//! Be less verbose
-	bool quiet;
+	//! Verbosity level from 0 (quiet) to 2 (extra verbose)
+	int verbosity;
 
 	bool transparent;
 

--- a/include/wkhtmltox/imagesettings.hh
+++ b/include/wkhtmltox/imagesettings.hh
@@ -1,3 +1,6 @@
+// -*- mode: c++; tab-width: 4; indent-tabs-mode: t; eval: (progn (c-set-style "stroustrup") (c-set-offset 'innamespace 0)); -*-
+// vi:set ts=4 sts=4 sw=4 noet :
+//
 // Copyright 2010 wkhtmltopdf authors
 //
 // This file is part of wkhtmltopdf.
@@ -19,6 +22,7 @@
 #define __IMAGESETTINGS_HH__
 
 #include <QString>
+#include <wkhtmltox/logging.hh>
 #include <wkhtmltox/loadsettings.hh>
 #include <wkhtmltox/websettings.hh>
 
@@ -57,8 +61,8 @@ struct DLL_PUBLIC ImageGlobal {
 	LoadPage loadPage;
 	Web web;
 
-	//! Verbosity level from 0 (quiet) to 2 (extra verbose)
-	int verbosity;
+	//! Log level
+	LogLevel logLevel;
 
 	bool transparent;
 

--- a/include/wkhtmltox/logging.hh
+++ b/include/wkhtmltox/logging.hh
@@ -1,0 +1,43 @@
+// -*- mode: c++; tab-width: 4; indent-tabs-mode: t; eval: (progn (c-set-style "stroustrup") (c-set-offset 'innamespace 0)); -*-
+// vi:set ts=4 sts=4 sw=4 noet :
+//
+// Copyright 2010 wkhtmltopdf authors
+//
+// This file is part of wkhtmltopdf.
+//
+// wkhtmltopdf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// wkhtmltopdf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with wkhtmltopdf.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef __LOGGING_HH__
+#define __LOGGING_HH__
+
+#include <QMap>
+#include <QString>
+#include <wkhtmltox/dllbegin.inc>
+namespace wkhtmltopdf {
+namespace settings {
+
+enum LogLevel {
+	None,
+	Error,
+	Warn,
+	Info
+};
+
+DLL_PUBLIC LogLevel strToLogLevel(const char * s, bool * ok=0);
+DLL_PUBLIC QString logLevelToStr(const LogLevel & l, bool * ok=0);
+
+}
+}
+#include <wkhtmltox/dllend.inc>
+#endif //__LOGGING_HH__

--- a/include/wkhtmltox/multipageloader.hh
+++ b/include/wkhtmltox/multipageloader.hh
@@ -45,7 +45,7 @@ class DLL_LOCAL MultiPageLoaderPrivate;
 class DLL_LOCAL MultiPageLoader: public QObject {
 	Q_OBJECT
 public:
-	MultiPageLoader(settings::LoadGlobal & s, bool mainLoader = false);
+	MultiPageLoader(settings::LoadGlobal & s, int dpi, bool mainLoader = false);
 	~MultiPageLoader();
 	LoaderObject * addResource(const QString & url, const settings::LoadPage & settings, const QString * data=NULL);
 	LoaderObject * addResource(const QUrl & url, const settings::LoadPage & settings);

--- a/include/wkhtmltox/pdfsettings.hh
+++ b/include/wkhtmltox/pdfsettings.hh
@@ -82,8 +82,8 @@ struct DLL_PUBLIC PdfGlobal {
 	//! Size related settings
 	Size size;
 
-	//! Be less verbose
-	bool quiet;
+	//! Verbosity level from 0 (quiet) to 2 (extra verbose)
+	int verbosity;
 
 	//! Should we use the graphics system
 	bool useGraphics;

--- a/include/wkhtmltox/pdfsettings.hh
+++ b/include/wkhtmltox/pdfsettings.hh
@@ -1,3 +1,6 @@
+// -*- mode: c++; tab-width: 4; indent-tabs-mode: t; eval: (progn (c-set-style "stroustrup") (c-set-offset 'innamespace 0)); -*-
+// vi:set ts=4 sts=4 sw=4 noet :
+//
 // Copyright 2010 wkhtmltopdf authors
 //
 // This file is part of wkhtmltopdf.
@@ -21,6 +24,7 @@
 #include <QNetworkProxy>
 #include <QPrinter>
 #include <QString>
+#include <wkhtmltox/logging.hh>
 #include <wkhtmltox/loadsettings.hh>
 #include <wkhtmltox/websettings.hh>
 
@@ -82,13 +86,13 @@ struct DLL_PUBLIC PdfGlobal {
 	//! Size related settings
 	Size size;
 
-	//! Verbosity level from 0 (quiet) to 2 (extra verbose)
-	int verbosity;
+	//! Log level
+	LogLevel logLevel;
 
 	//! Should we use the graphics system
 	bool useGraphics;
-	
-	//! Should relative links be resolved
+
+	//! Should relative links be resolved or kept as-is
 	bool resolveRelativeLinks;
 
 	//! Should we orientate in landscape or portrate

--- a/src/image/imagearguments.cc
+++ b/src/image/imagearguments.cc
@@ -31,8 +31,8 @@ ImageCommandLineParser::ImageCommandLineParser(wkhtmltopdf::settings::ImageGloba
 
 	extended(false);
 	qthack(false);
-	addarg("quiet", 'q', "Be less verbose, maintained for backwards compatibility; it corresponds to --verbosity level 0 (true) and 1 (false)", new ConstSetter<int>(s.verbosity, 0));
-	addarg("verbosity", 'v', "Verbosity level from 0 (quiet) to 2 (extra verbose)", new IntSetter(s.verbosity, "number"));
+	addarg("quiet", 'q', "Be less verbose, maintained for backwards compatibility; Same as using --log-level none", new ConstSetter<wkhtmltopdf::settings::LogLevel>(s.logLevel, wkhtmltopdf::settings::None));
+	addarg("log-level", 0, "Set log level to: none, error, warn or info", new LogLevelSetter(s.logLevel, "level"));
 	addarg("width",0,"Set screen width, note that this is used only as a guide line. Use --disable-smart-width to make it strict.", new IntSetter(s.screenWidth,"int"));
 	addarg("height",0,"Set screen height (default is calculated from page content)", new IntSetter(s.screenHeight, "int"));
 	// addarg("scale-w",0,"Set width for resizing", new IntSetter(s.scale.width,"int"));

--- a/src/image/imagearguments.cc
+++ b/src/image/imagearguments.cc
@@ -31,7 +31,8 @@ ImageCommandLineParser::ImageCommandLineParser(wkhtmltopdf::settings::ImageGloba
 
 	extended(false);
 	qthack(false);
-	addarg("quiet", 'q', "Be less verbose", new ConstSetter<bool>(s.quiet,true));
+	addarg("quiet", 'q', "Be less verbose, maintained for backwards compatibility; it corresponds to --verbosity level 0 (true) and 1 (false)", new ConstSetter<int>(s.verbosity, 0));
+	addarg("verbosity", 'v', "Verbosity level from 0 (quiet) to 2 (extra verbose)", new IntSetter(s.verbosity, "number"));
 	addarg("width",0,"Set screen width, note that this is used only as a guide line. Use --disable-smart-width to make it strict.", new IntSetter(s.screenWidth,"int"));
 	addarg("height",0,"Set screen height (default is calculated from page content)", new IntSetter(s.screenHeight, "int"));
 	// addarg("scale-w",0,"Set width for resizing", new IntSetter(s.scale.width,"int"));

--- a/src/image/wkhtmltoimage.cc
+++ b/src/image/wkhtmltoimage.cc
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
 	QObject::connect(&converter, SIGNAL(radiobuttonSvgChanged(const QString &)), style, SLOT(setRadioButtonSvg(const QString &)));
 	QObject::connect(&converter, SIGNAL(radiobuttonCheckedSvgChanged(const QString &)), style, SLOT(setRadioButtonCheckedSvg(const QString &)));
 
-	wkhtmltopdf::ProgressFeedback feedback(settings.quiet, converter);
+	wkhtmltopdf::ProgressFeedback feedback(settings.verbosity, converter);
 	bool success = converter.convert();
 	return handleError(success, converter.httpErrorCode());
 }

--- a/src/image/wkhtmltoimage.cc
+++ b/src/image/wkhtmltoimage.cc
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
 	QObject::connect(&converter, SIGNAL(radiobuttonSvgChanged(const QString &)), style, SLOT(setRadioButtonSvg(const QString &)));
 	QObject::connect(&converter, SIGNAL(radiobuttonCheckedSvgChanged(const QString &)), style, SLOT(setRadioButtonCheckedSvg(const QString &)));
 
-	wkhtmltopdf::ProgressFeedback feedback(settings.verbosity, converter);
+	wkhtmltopdf::ProgressFeedback feedback(settings.logLevel, converter);
 	bool success = converter.convert();
 	return handleError(success, converter.httpErrorCode());
 }

--- a/src/lib/converter.hh
+++ b/src/lib/converter.hh
@@ -35,7 +35,7 @@ public:
 	virtual ~Converter() {};
 
     int currentPhase();
-	int phaseCount();
+    int phaseCount();
     QString phaseDescription(int phase=-1);
     QString progressString();
     int httpErrorCode();

--- a/src/lib/image_c_bindings.cc
+++ b/src/lib/image_c_bindings.cc
@@ -49,11 +49,11 @@
 using namespace wkhtmltopdf;
 
 void MyImageConverter::warning(const QString & message) {
-	if (warning_cb) (warning_cb)(reinterpret_cast<wkhtmltoimage_converter*>(this), message.toUtf8().constData());
+	if (warning_cb && globalSettings->logLevel > settings::Error) (warning_cb)(reinterpret_cast<wkhtmltoimage_converter*>(this), message.toUtf8().constData());
 }
 
 void MyImageConverter::error(const QString & message) {
-	if (error_cb) (error_cb)(reinterpret_cast<wkhtmltoimage_converter*>(this), message.toUtf8().constData());
+	if (error_cb && globalSettings->logLevel > settings::None) (error_cb)(reinterpret_cast<wkhtmltoimage_converter*>(this), message.toUtf8().constData());
 }
 
 void MyImageConverter::phaseChanged() {
@@ -104,7 +104,7 @@ CAPI(wkhtmltoimage_global_settings *) wkhtmltoimage_create_global_settings() {
 }
 
 CAPI(void) wkhtmltoimage_destroy_global_settings(wkhtmltoimage_global_settings * obj) {
-	delete reinterpret_cast<settings::ImageGlobal *>(obj);
+    delete reinterpret_cast<settings::ImageGlobal *>(obj);
 }
 
 CAPI(int) wkhtmltoimage_set_global_setting(wkhtmltoimage_global_settings * settings, const char * name, const char * value) {

--- a/src/lib/imagesettings.cc
+++ b/src/lib/imagesettings.cc
@@ -41,7 +41,8 @@ struct DLL_LOCAL ReflectImpl<ImageGlobal>: public ReflectClass {
 	ReflectImpl(ImageGlobal & c) {
 		WKHTMLTOPDF_REFLECT(screenWidth);
 		WKHTMLTOPDF_REFLECT(screenHeight);
-		WKHTMLTOPDF_REFLECT(quiet);
+		ReflectClass::add("quiet", new QuietArgBackwardsCompatReflect(c.verbosity));	// Fake the "quiet" argument
+		WKHTMLTOPDF_REFLECT(verbosity);
 		WKHTMLTOPDF_REFLECT(transparent);
 		WKHTMLTOPDF_REFLECT(useGraphics);
 		WKHTMLTOPDF_REFLECT(in);
@@ -60,7 +61,7 @@ CropSettings::CropSettings():
 	height(-1) {}
 
 ImageGlobal::ImageGlobal():
-	quiet(false),
+	verbosity(1),
 	transparent(false),
 	useGraphics(false),
 	in(""),

--- a/src/lib/imagesettings.cc
+++ b/src/lib/imagesettings.cc
@@ -41,8 +41,8 @@ struct DLL_LOCAL ReflectImpl<ImageGlobal>: public ReflectClass {
 	ReflectImpl(ImageGlobal & c) {
 		WKHTMLTOPDF_REFLECT(screenWidth);
 		WKHTMLTOPDF_REFLECT(screenHeight);
-		ReflectClass::add("quiet", new QuietArgBackwardsCompatReflect(c.verbosity));	// Fake the "quiet" argument
-		WKHTMLTOPDF_REFLECT(verbosity);
+		ReflectClass::add("quiet", new QuietArgBackwardsCompatReflect(c.logLevel));	// Fake the "quiet" argument
+		WKHTMLTOPDF_REFLECT(logLevel);
 		WKHTMLTOPDF_REFLECT(transparent);
 		WKHTMLTOPDF_REFLECT(useGraphics);
 		WKHTMLTOPDF_REFLECT(in);
@@ -61,7 +61,7 @@ CropSettings::CropSettings():
 	height(-1) {}
 
 ImageGlobal::ImageGlobal():
-	verbosity(1),
+	logLevel(Info),
 	transparent(false),
 	useGraphics(false),
 	in(""),

--- a/src/lib/imagesettings.hh
+++ b/src/lib/imagesettings.hh
@@ -22,6 +22,7 @@
 #define __IMAGESETTINGS_HH__
 
 #include <QString>
+#include <wkhtmltox/logging.hh>
 #include <wkhtmltox/loadsettings.hh>
 #include <wkhtmltox/websettings.hh>
 
@@ -60,8 +61,8 @@ struct DLL_PUBLIC ImageGlobal {
 	LoadPage loadPage;
 	Web web;
 
-	//! Verbosity level from 0 (quiet) to 2 (extra verbose)
-	int verbosity;
+	//! Log level
+	LogLevel logLevel;
 
 	bool transparent;
 

--- a/src/lib/imagesettings.hh
+++ b/src/lib/imagesettings.hh
@@ -60,8 +60,8 @@ struct DLL_PUBLIC ImageGlobal {
 	LoadPage loadPage;
 	Web web;
 
-	//! Be less verbose
-	bool quiet;
+	//! Verbosity level from 0 (quiet) to 2 (extra verbose)
+	int verbosity;
 
 	bool transparent;
 

--- a/src/lib/lib.pri
+++ b/src/lib/lib.pri
@@ -22,8 +22,8 @@ PUBLIC_HEADERS += ../lib/converter.hh ../lib/multipageloader.hh ../lib/dllbegin.
 PUBLIC_HEADERS += ../lib/dllend.inc ../lib/loadsettings.hh ../lib/websettings.hh
 PUBLIC_HEADERS += ../lib/utilities.hh
 HEADERS += ../lib/multipageloader_p.hh  ../lib/converter_p.hh
-SOURCES += ../lib/loadsettings.cc ../lib/multipageloader.cc ../lib/tempfile.cc \
-	   ../lib/converter.cc ../lib/websettings.cc  \
+SOURCES += ../lib/loadsettings.cc ../lib/logging.cc ../lib/multipageloader.cc \
+	   ../lib/tempfile.cc ../lib/converter.cc ../lib/websettings.cc  \
   	   ../lib/reflect.cc ../lib/utilities.cc
 
 #Pdf

--- a/src/lib/logging.cc
+++ b/src/lib/logging.cc
@@ -1,0 +1,62 @@
+// -*- mode: c++; tab-width: 4; indent-tabs-mode: t; eval: (progn (c-set-style "stroustrup") (c-set-offset 'innamespace 0)); -*-
+// vi:set ts=4 sts=4 sw=4 noet :
+//
+// Copyright 2010 wkhtmltopdf authors
+//
+// This file is part of wkhtmltopdf.
+//
+// wkhtmltopdf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// wkhtmltopdf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with wkhtmltopdf.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "logging.hh"
+#include <QMap>
+#include <QString>
+#include <wkhtmltox/dllbegin.inc>
+namespace wkhtmltopdf {
+namespace settings {
+
+// Centralized name-to-enum value mapping
+QMap<QString, LogLevel> logLevelMap() {
+	QMap<QString, LogLevel> res;
+	res["none"] = None;
+	res["error"] = Error;
+	res["warn"] = Warn;
+	res["info"] = Info;
+	return res;
+}
+
+QMap<QString, LogLevel> logLevels = logLevelMap();
+
+LogLevel strToLogLevel(const char * s, bool * ok) {
+	for (QMap<QString, LogLevel>::const_iterator i = logLevels.begin(); i != logLevels.end(); ++i) {
+		if (i.key().compare(s, Qt::CaseInsensitive) != 0) continue;
+		if (ok) *ok = true;
+		return i.value();
+	}
+	if (ok) *ok = false;
+	return Info;
+}
+
+QString logLevelToStr(const LogLevel & l, bool * ok) {
+	for (QMap<QString, LogLevel>::const_iterator i = logLevels.begin(); i != logLevels.end(); ++i) {
+		if (i.value() != l) continue;
+		if (ok) *ok = true;
+		return i.key();
+	}
+	if (ok) *ok = false;
+	return QString();
+}
+
+}
+}
+#include <wkhtmltox/dllend.inc>

--- a/src/lib/logging.hh
+++ b/src/lib/logging.hh
@@ -1,0 +1,43 @@
+// -*- mode: c++; tab-width: 4; indent-tabs-mode: t; eval: (progn (c-set-style "stroustrup") (c-set-offset 'innamespace 0)); -*-
+// vi:set ts=4 sts=4 sw=4 noet :
+//
+// Copyright 2010 wkhtmltopdf authors
+//
+// This file is part of wkhtmltopdf.
+//
+// wkhtmltopdf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// wkhtmltopdf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with wkhtmltopdf.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef __LOGGING_HH__
+#define __LOGGING_HH__
+
+#include <QMap>
+#include <QString>
+#include <wkhtmltox/dllbegin.inc>
+namespace wkhtmltopdf {
+namespace settings {
+
+enum LogLevel {
+	None,
+	Error,
+	Warn,
+	Info
+};
+
+DLL_PUBLIC LogLevel strToLogLevel(const char * s, bool * ok=0);
+DLL_PUBLIC QString logLevelToStr(const LogLevel & l, bool * ok=0);
+
+}
+}
+#include <wkhtmltox/dllend.inc>
+#endif //__LOGGING_HH__

--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -209,11 +209,11 @@ QApplication * a = 0;
 int usage = 0;
 
 void MyPdfConverter::warning(const QString & message) {
-	if (warning_cb) (warning_cb)(reinterpret_cast<wkhtmltopdf_converter*>(this), message.toUtf8().constData());
+	if (warning_cb && globalSettings->logLevel > settings::Error) (warning_cb)(reinterpret_cast<wkhtmltopdf_converter*>(this), message.toUtf8().constData());
 }
 
 void MyPdfConverter::error(const QString & message) {
-	if (error_cb) (error_cb)(reinterpret_cast<wkhtmltopdf_converter*>(this), message.toUtf8().constData());
+	if (error_cb && globalSettings->logLevel > settings::None) (error_cb)(reinterpret_cast<wkhtmltopdf_converter*>(this), message.toUtf8().constData());
 }
 
 void MyPdfConverter::phaseChanged() {

--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -107,8 +107,8 @@ template<>
 struct DLL_LOCAL ReflectImpl<PdfGlobal>: public ReflectClass {
 	ReflectImpl(PdfGlobal & c) {
 		WKHTMLTOPDF_REFLECT(size);
-		ReflectClass::add("quiet", new QuietArgBackwardsCompatReflect(c.verbosity));	// Fake the "quiet" argument
-		WKHTMLTOPDF_REFLECT(verbosity);
+		ReflectClass::add("quiet", new QuietArgBackwardsCompatReflect(c.logLevel));	// Fake the "quiet" argument
+		WKHTMLTOPDF_REFLECT(logLevel);
 		WKHTMLTOPDF_REFLECT(useGraphics);
 		WKHTMLTOPDF_REFLECT(resolveRelativeLinks);
 		WKHTMLTOPDF_REFLECT(orientation);
@@ -369,7 +369,7 @@ Margin::Margin():
 	left(UnitReal(10,QPrinter::Millimeter)) {}
 
 PdfGlobal::PdfGlobal():
-	verbosity(1),
+	logLevel(Info),
 	useGraphics(false),
 	resolveRelativeLinks(true),
 	orientation(QPrinter::Portrait),

--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -107,7 +107,8 @@ template<>
 struct DLL_LOCAL ReflectImpl<PdfGlobal>: public ReflectClass {
 	ReflectImpl(PdfGlobal & c) {
 		WKHTMLTOPDF_REFLECT(size);
-		WKHTMLTOPDF_REFLECT(quiet);
+		ReflectClass::add("quiet", new QuietArgBackwardsCompatReflect(c.verbosity));	// Fake the "quiet" argument
+		WKHTMLTOPDF_REFLECT(verbosity);
 		WKHTMLTOPDF_REFLECT(useGraphics);
 		WKHTMLTOPDF_REFLECT(resolveRelativeLinks);
 		WKHTMLTOPDF_REFLECT(orientation);
@@ -368,7 +369,7 @@ Margin::Margin():
 	left(UnitReal(10,QPrinter::Millimeter)) {}
 
 PdfGlobal::PdfGlobal():
-	quiet(false),
+	verbosity(1),
 	useGraphics(false),
 	resolveRelativeLinks(true),
 	orientation(QPrinter::Portrait),

--- a/src/lib/pdfsettings.hh
+++ b/src/lib/pdfsettings.hh
@@ -85,8 +85,8 @@ struct DLL_PUBLIC PdfGlobal {
 	//! Size related settings
 	Size size;
 
-	//! Be less verbose
-	bool quiet;
+	//! Verbosity level from 0 (quiet) to 2 (extra verbose)
+	int verbosity;
 
 	//! Should we use the graphics system
 	bool useGraphics;

--- a/src/lib/pdfsettings.hh
+++ b/src/lib/pdfsettings.hh
@@ -24,6 +24,7 @@
 #include <QNetworkProxy>
 #include <QPrinter>
 #include <QString>
+#include <wkhtmltox/logging.hh>
 #include <wkhtmltox/loadsettings.hh>
 #include <wkhtmltox/websettings.hh>
 
@@ -85,8 +86,8 @@ struct DLL_PUBLIC PdfGlobal {
 	//! Size related settings
 	Size size;
 
-	//! Verbosity level from 0 (quiet) to 2 (extra verbose)
-	int verbosity;
+	//! Log level
+	LogLevel logLevel;
 
 	//! Should we use the graphics system
 	bool useGraphics;

--- a/src/lib/reflect.hh
+++ b/src/lib/reflect.hh
@@ -61,6 +61,22 @@ public:
 	~ReflectClass();
 };
 
+class DLL_LOCAL QuietArgBackwardsCompatReflect: public ReflectSimple {
+	int & v;
+public:
+	QuietArgBackwardsCompatReflect(int & _): v(_) {}
+	QString get() {return v?"false":"true";}
+	void set(const QString & value, bool * ok) {
+		if (value == "true") v=0;
+		else if (value == "false") v=1;
+		else {
+			*ok=false;
+			return;
+		}
+		*ok=true;
+	}
+};
+
 template <typename X>
 class DLL_LOCAL ReflectImpl {
 private:

--- a/src/lib/reflect.hh
+++ b/src/lib/reflect.hh
@@ -25,6 +25,7 @@
 #define typeof decltype
 #endif
 
+#include "logging.hh"
 #include "loadsettings.hh"
 #include "websettings.hh"
 #include <QStringList>
@@ -62,13 +63,13 @@ public:
 };
 
 class DLL_LOCAL QuietArgBackwardsCompatReflect: public ReflectSimple {
-	int & v;
+	LogLevel & l;
 public:
-	QuietArgBackwardsCompatReflect(int & _): v(_) {}
-	QString get() {return v?"false":"true";}
+	QuietArgBackwardsCompatReflect(LogLevel & _): l(_) {}
+	QString get() {return l == None ? "true":"false";}
 	void set(const QString & value, bool * ok) {
-		if (value == "true") v=0;
-		else if (value == "false") v=1;
+		if (value == "true") l=None;
+		else if (value == "false") l=Info;
 		else {
 			*ok=false;
 			return;
@@ -81,6 +82,18 @@ template <typename X>
 class DLL_LOCAL ReflectImpl {
 private:
 	ReflectImpl();
+};
+
+template<>
+struct DLL_LOCAL ReflectImpl<LogLevel>: public ReflectSimple {
+	LogLevel & l;
+	ReflectImpl(LogLevel & _): l(_) {	}
+	QString get() {
+		return logLevelToStr(l, 0);
+	}
+	void set(const QString & value, bool * ok) {
+		l = strToLogLevel(qPrintable(value), ok);
+	}
 };
 
 template<>

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -176,8 +176,8 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
 	extended(false);
 	qthack(false);
 
-	addarg("quiet", 'q', "Be less verbose, maintained for backwards compatibility; it corresponds to --verbosity level 0 (true) and 1 (false)", new ConstSetter<int>(s.verbosity, 0));
-	addarg("verbosity", 'v', "Verbosity level from 0 (quiet) to 2 (extra verbose)", new IntSetter(s.verbosity, "number"));
+	addarg("quiet", 'q', "Be less verbose, maintained for backwards compatibility; Same as using --log-level none", new ConstSetter<LogLevel>(s.logLevel, None));
+	addarg("log-level", 0, "Set log level to: none, error, warn or info", new LogLevelSetter(s.logLevel, "level"));
 
 	addarg("no-collate", 0, "Do not collate when printing multiple copies", new ConstSetter<bool>(s.collate, false));
 	addarg("collate", 0, "Collate when printing multiple copies", new ConstSetter<bool>(s.collate, true));

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -176,7 +176,8 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
 	extended(false);
 	qthack(false);
 
-	addarg("quiet", 'q', "Be less verbose", new ConstSetter<bool>(s.quiet,true));
+	addarg("quiet", 'q', "Be less verbose, maintained for backwards compatibility; it corresponds to --verbosity level 0 (true) and 1 (false)", new ConstSetter<int>(s.verbosity, 0));
+	addarg("verbosity", 'v', "Verbosity level from 0 (quiet) to 2 (extra verbose)", new IntSetter(s.verbosity, "number"));
 
 	addarg("no-collate", 0, "Do not collate when printing multiple copies", new ConstSetter<bool>(s.collate, false));
 	addarg("collate", 0, "Collate when printing multiple copies", new ConstSetter<bool>(s.collate, true));

--- a/src/pdf/wkhtmltopdf.cc
+++ b/src/pdf/wkhtmltopdf.cc
@@ -208,7 +208,7 @@ int main(int argc, char * argv[]) {
 			parser.parseArguments(nargc, (const char**)nargv, true);
 
 			PdfConverter converter(globalSettings);
-			ProgressFeedback feedback(globalSettings.quiet, converter);
+			ProgressFeedback feedback(globalSettings.verbosity, converter);
 			foreach (const PdfObject & object, objectSettings)
 				converter.addResource(object);
 
@@ -227,7 +227,7 @@ int main(int argc, char * argv[]) {
 	QObject::connect(&converter, SIGNAL(radiobuttonSvgChanged(const QString &)), style, SLOT(setRadioButtonSvg(const QString &)));
 	QObject::connect(&converter, SIGNAL(radiobuttonCheckedSvgChanged(const QString &)), style, SLOT(setRadioButtonCheckedSvg(const QString &)));
 
-	ProgressFeedback feedback(globalSettings.quiet, converter);
+	ProgressFeedback feedback(globalSettings.verbosity, converter);
 	foreach (const PdfObject & object, objectSettings)
 		converter.addResource(object);
 

--- a/src/pdf/wkhtmltopdf.cc
+++ b/src/pdf/wkhtmltopdf.cc
@@ -208,7 +208,7 @@ int main(int argc, char * argv[]) {
 			parser.parseArguments(nargc, (const char**)nargv, true);
 
 			PdfConverter converter(globalSettings);
-			ProgressFeedback feedback(globalSettings.verbosity, converter);
+			ProgressFeedback feedback(globalSettings.logLevel, converter);
 			foreach (const PdfObject & object, objectSettings)
 				converter.addResource(object);
 
@@ -227,7 +227,7 @@ int main(int argc, char * argv[]) {
 	QObject::connect(&converter, SIGNAL(radiobuttonSvgChanged(const QString &)), style, SLOT(setRadioButtonSvg(const QString &)));
 	QObject::connect(&converter, SIGNAL(radiobuttonCheckedSvgChanged(const QString &)), style, SLOT(setRadioButtonCheckedSvg(const QString &)));
 
-	ProgressFeedback feedback(globalSettings.verbosity, converter);
+	ProgressFeedback feedback(globalSettings.logLevel, converter);
 	foreach (const PdfObject & object, objectSettings)
 		converter.addResource(object);
 

--- a/src/shared/arghandler.inl
+++ b/src/shared/arghandler.inl
@@ -22,6 +22,7 @@
 #define __ARGHANDLER_INL__
 #include "commandlineparserbase.hh"
 #include <wkhtmltox/loadsettings.hh>
+#include <wkhtmltox/logging.hh>
 
 template <typename T> class DstArgHandler: public ArgHandler {
 public:
@@ -164,6 +165,19 @@ struct FloatTM: public SomeSetterTM<float> {
   Argument handler setting an float variable
 */
 typedef SomeSetter<FloatTM> FloatSetter;
+
+struct LogLevelTM: public SomeSetterTM<wkhtmltopdf::settings::LogLevel> {
+	static wkhtmltopdf::settings::LogLevel strToT(const char * val, bool & ok) {
+		return wkhtmltopdf::settings::strToLogLevel(val, &ok);
+	}
+	static QString TToStr(const wkhtmltopdf::settings::LogLevel & l, bool & ok) {
+		return wkhtmltopdf::settings::logLevelToStr(l, &ok);
+	}
+};
+/*!
+  Argument handler setting an loglevel variable
+*/
+typedef SomeSetter<LogLevelTM> LogLevelSetter;
 
 struct StrTM: public SomeSetterTM<const char *> {
 	static const char * strToT(const char * val, bool & ok) {

--- a/src/shared/progressfeedback.cc
+++ b/src/shared/progressfeedback.cc
@@ -38,7 +38,7 @@ namespace wkhtmltopdf {
   \param message The warning message
 */
 void ProgressFeedback::warning(const QString &message) {
-	if (quiet) return;
+	if (verbosity < 2) return;
 	fprintf(stderr, "Warning: %s",S(message));
 	for (int l = 9 + message.size(); l < lw; ++l)
 		fprintf(stderr, " ");
@@ -62,7 +62,7 @@ void ProgressFeedback::error(const QString &message) {
   \brief Write out the name of the next phase
 */
 void ProgressFeedback::phaseChanged() {
-	if (quiet) return;
+	if (verbosity < 1) return;
 	QString desc=converter.phaseDescription();
 	fprintf(stderr, "%s", S(desc));
 
@@ -79,7 +79,7 @@ void ProgressFeedback::phaseChanged() {
   \brief Update progress bar
 */
 void ProgressFeedback::progressChanged(int progress) {
-	if (quiet) return;
+	if (verbosity < 1) return;
 	fprintf(stderr, "[");
 	int w=60;
 	progress *= w;
@@ -97,8 +97,8 @@ void ProgressFeedback::progressChanged(int progress) {
 	fprintf(stderr, "\r");
 }
 
-ProgressFeedback::ProgressFeedback(bool q, Converter & _):
-    quiet(q), converter(_), lw(0) {
+ProgressFeedback::ProgressFeedback(int v, Converter & _):
+    verbosity(v), converter(_), lw(0) {
     connect(&converter, SIGNAL(warning(const QString &)), this, SLOT(warning(const QString &)));
 	connect(&converter, SIGNAL(error(const QString &)), this, SLOT(error(const QString &)));
 	connect(&converter, SIGNAL(phaseChanged()), this, SLOT(phaseChanged()));

--- a/src/shared/progressfeedback.cc
+++ b/src/shared/progressfeedback.cc
@@ -38,7 +38,7 @@ namespace wkhtmltopdf {
   \param message The warning message
 */
 void ProgressFeedback::warning(const QString &message) {
-	if (verbosity < 2) return;
+	if (logLevel < settings::Warn) return;
 	fprintf(stderr, "Warning: %s",S(message));
 	for (int l = 9 + message.size(); l < lw; ++l)
 		fprintf(stderr, " ");
@@ -51,6 +51,7 @@ void ProgressFeedback::warning(const QString &message) {
   \param message The error message
 */
 void ProgressFeedback::error(const QString &message) {
+	if (logLevel < settings::Error) return;
 	fprintf(stderr, "Error: %s",S(message));
 	for (int l = 7 + message.size(); l < lw; ++l)
 		fprintf(stderr, " ");
@@ -62,7 +63,7 @@ void ProgressFeedback::error(const QString &message) {
   \brief Write out the name of the next phase
 */
 void ProgressFeedback::phaseChanged() {
-	if (verbosity < 1) return;
+	if (logLevel < settings::Info) return;
 	QString desc=converter.phaseDescription();
 	fprintf(stderr, "%s", S(desc));
 
@@ -79,7 +80,7 @@ void ProgressFeedback::phaseChanged() {
   \brief Update progress bar
 */
 void ProgressFeedback::progressChanged(int progress) {
-	if (verbosity < 1) return;
+	if (logLevel < settings::Info) return;
 	fprintf(stderr, "[");
 	int w=60;
 	progress *= w;
@@ -97,8 +98,8 @@ void ProgressFeedback::progressChanged(int progress) {
 	fprintf(stderr, "\r");
 }
 
-ProgressFeedback::ProgressFeedback(int v, Converter & _):
-    verbosity(v), converter(_), lw(0) {
+ProgressFeedback::ProgressFeedback(settings::LogLevel l, Converter & _):
+    logLevel(l), converter(_), lw(0) {
     connect(&converter, SIGNAL(warning(const QString &)), this, SLOT(warning(const QString &)));
 	connect(&converter, SIGNAL(error(const QString &)), this, SLOT(error(const QString &)));
 	connect(&converter, SIGNAL(phaseChanged()), this, SLOT(phaseChanged()));

--- a/src/shared/progressfeedback.hh
+++ b/src/shared/progressfeedback.hh
@@ -21,12 +21,13 @@
 #ifndef __PROGRESSFEEDBACK_HH__
 #define __PROGRESSFEEDBACK_HH__
 #include <wkhtmltox/converter.hh>
+#include <wkhtmltox/logging.hh>
 namespace wkhtmltopdf {
 
 class ProgressFeedback: public QObject {
 	Q_OBJECT
 private:
-	int verbosity;
+	settings::LogLevel logLevel;
 	Converter & converter;
 	int lw;
 public slots:
@@ -35,7 +36,7 @@ public slots:
 	void phaseChanged();
 	void progressChanged(int progress);
 public:
-	ProgressFeedback(int verbosity, Converter & _);
+	ProgressFeedback(settings::LogLevel logLevel, Converter & _);
 };
 
 }

--- a/src/shared/progressfeedback.hh
+++ b/src/shared/progressfeedback.hh
@@ -26,7 +26,7 @@ namespace wkhtmltopdf {
 class ProgressFeedback: public QObject {
 	Q_OBJECT
 private:
-	bool quiet;
+	int verbosity;
 	Converter & converter;
 	int lw;
 public slots:
@@ -35,7 +35,7 @@ public slots:
 	void phaseChanged();
 	void progressChanged(int progress);
 public:
-	ProgressFeedback(bool quiet, Converter & _);
+	ProgressFeedback(int verbosity, Converter & _);
 };
 
 }


### PR DESCRIPTION
Verbosity levels 0 (none), 1 (info) and 2 (extra) are supported. Current option 'quiet' is kept for backwards compatibility. It has been mapped to the new 'verbosity' values 0 (--quiet=true) and 1 (--quiet=false).
