### PR TITLE
Fix for DPI issue on OS X

### DIFF
--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -265,11 +265,11 @@ qreal PdfConverterPrivate::calculateHeaderHeight(PageObject & object, QWebPage &
 
 QPrinter * PdfConverterPrivate::createPrinter(const QString & tempFile) {
     QPrinter * printer = new QPrinter(settings.resolution);
-    printer->setResolution(settings.dpi);
     //Tell the printer object to print the file <out>
 
     printer->setOutputFileName(tempFile);
     printer->setOutputFormat(QPrinter::PdfFormat);
+    printer->setResolution(settings.dpi);
 
     if ((settings.size.height.first != -1) && (settings.size.width.first != -1)) {
         printer->setPaperSize(QSizeF(settings.size.width.first,settings.size.height.first + 100), settings.size.height.second);
@@ -344,11 +344,11 @@ void PdfConverterPrivate::pagesLoaded(bool ok) {
 	  lout = tempOut.create(".pdf");
 
 	printer = new QPrinter(settings.resolution);
-	printer->setResolution(settings.dpi);
 	//Tell the printer object to print the file <out>
 
 	printer->setOutputFileName(lout);
 	printer->setOutputFormat(QPrinter::PdfFormat);
+	printer->setResolution(settings.dpi);
 
 	//We currently only support margins with the same unit
 	if (settings.margin.left.second != settings.margin.right.second ||


### PR DESCRIPTION
On OS X, the resolution is clamped to default output device's supported resolutions. Then, when changing the device to PDF, the clamped value would be used, rather than the desired resolution. This typically resulted in tiny text, possibly more likely on retina displays. Simply setting the resolution after the PDF format is selected fixes the issue.

This was tested on OS X and fixes #3241 (see there for details)