### PR TITLE
Added viewportSize to ReflectImpl<PdfGlobal>

### DIFF
--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -128,6 +128,7 @@ struct DLL_LOCAL ReflectImpl<PdfGlobal>: public ReflectClass {
 		WKHTMLTOPDF_REFLECT(imageDPI);
 		WKHTMLTOPDF_REFLECT(imageQuality);
 		WKHTMLTOPDF_REFLECT(load);
+		WKHTMLTOPDF_REFLECT(viewportSize);
 	}
 };
 


### PR DESCRIPTION
@ashkulz Is this enough or needs to be added also somewhere else. I checked pdfsettings.hh and viewportSize is already [defined](https://github.com/wkhtmltopdf/wkhtmltopdf/blob/c754e38b074a75a51327df36c4a53f8962020510/include/wkhtmltox/pdfsettings.hh#L138)

Proposed fix for [issue #2609](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2609)
