### PR TITLE
Fix typo in usage text

### DIFF
--- a/docs/usage/wkhtmltopdf.txt
+++ b/docs/usage/wkhtmltopdf.txt
@@ -246,7 +246,7 @@ Page sizes:
 
 Reading arguments from stdin:
   If you need to convert a lot of pages in a batch, and you feel that
-  wkhtmltopdf is a bit to slow to start up, then you should try
+  wkhtmltopdf is a bit too slow to start up, then you should try
   --read-args-from-stdin,
 
   When --read-args-from-stdin each line of input sent to wkhtmltopdf on stdin

--- a/docs/usage/wkhtmltopdf.txt
+++ b/docs/usage/wkhtmltopdf.txt
@@ -33,7 +33,7 @@ Document objects:
   All options that can be specified for a page object can also be specified for
   a toc, further more the options from the TOC Options section can also be
   applied. The table of content is generated via XSLT which means that it can be
-  styled to look however you want it to look. To get an aide of how to do this
+  styled to look however you want it to look. To get an idea of how to do this
   you can dump the default xslt document by supplying the
   --dump-default-toc-xsl, and the outline it works on by supplying
   --dump-outline, see the Outline Options section.

--- a/src/pdf/pdfdocparts.cc
+++ b/src/pdf/pdfdocparts.cc
@@ -313,7 +313,7 @@ void PdfCommandLineParser::outputDocStart(Outputter * o) const {
 void PdfCommandLineParser::outputArgsFromStdin(Outputter * o) const {
 	o->beginSection("Reading arguments from stdin");
 	o->paragraph("If you need to convert a lot of pages in a batch, and you feel that wkhtmltopdf "
-				 "is a bit to slow to start up, then you should try --read-args-from-stdin,");
+				 "is a bit too slow to start up, then you should try --read-args-from-stdin,");
 	o->paragraph("When --read-args-from-stdin each line of input sent to wkhtmltopdf on stdin "
 				 "will act as a separate invocation of wkhtmltopdf, with the arguments specified "
 				 "on the given line combined with the arguments given to wkhtmltopdf");

--- a/src/pdf/pdfdocparts.cc
+++ b/src/pdf/pdfdocparts.cc
@@ -77,7 +77,7 @@ void PdfCommandLineParser::outputSynopsis(Outputter * o) const {
 			"further more the options from the ");
 	o->sectionLink("TOC Options");
 	o->text(" section can also be applied. The table of contents is generated via XSLT which means "
-			"that it can be styled to look however you want it to look. To get an aide of how to "
+			"that it can be styled to look however you want it to look. To get an idea of how to "
 			"do this you can dump the default xslt document by supplying the --dump-default-toc-xsl, and the outline it works on by supplying --dump-outline, see the ");
 	o->sectionLink("Outline Options");
 	o->text(" section.");


### PR DESCRIPTION
Should be "too slow," usage text currently reads "to slow."