### PR TITLE
Improve network error message

### DIFF
--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -407,8 +407,8 @@ void ResourceObject::amfinished(QNetworkReply * reply) {
 			//      no HTTP access at all, so we want network errors to be reported
 			//      with a higher priority than HTTP ones.
 			//      See: http://doc-snapshot.qt-project.org/4.8/qnetworkreply.html#NetworkError-enum
-			error(QString("Failed to load %1, with network status code %2 and http status code %3")
-				.arg(reply->url().toString()).arg(networkStatus).arg(httpStatus));
+			error(QString("Failed to load %1, with network status code %2 and http status code %3 - %4")
+				.arg(reply->url().toString()).arg(networkStatus).arg(httpStatus).arg(reply->errorString()));
 			httpErrorCode = networkStatus > 0 ? (networkStatus + 1000) : httpStatus;
 			return;
 		}


### PR DESCRIPTION
The network and http status codes that get printed whenever a network error occurs do not always adequately help explain what's happening. Printing the QNetworkReply::errorString() alongside the codes helps clarify some errors.