### PR TITLE
Add a setting to perform hostname lookup via proxy

### DIFF
--- a/include/wkhtmltox/loadsettings.hh
+++ b/include/wkhtmltox/loadsettings.hh
@@ -129,6 +129,9 @@ struct DLL_PUBLIC LoadPage {
 
 	// Hosts to bypass
 	QList< QString > bypassProxyForHosts;
+
+	//! Whether to use the proxy for resolving hostnames
+	bool proxyHostNameLookup;
 };
 
 DLL_PUBLIC LoadPage::LoadErrorHandling strToLoadErrorHandling(const char * s, bool * ok=0);

--- a/src/lib/loadsettings.cc
+++ b/src/lib/loadsettings.cc
@@ -145,7 +145,8 @@ LoadPage::LoadPage():
 	debugJavascript(false),
 	loadErrorHandling(abort),
 	mediaLoadErrorHandling(ignore),
-	cacheDir("") {};
+	cacheDir(""),
+	proxyHostNameLookup(false) {};
 
 }
 }

--- a/src/lib/loadsettings.hh
+++ b/src/lib/loadsettings.hh
@@ -132,6 +132,9 @@ struct DLL_PUBLIC LoadPage {
 
 	// Hosts to bypass
 	QList< QString > bypassProxyForHosts;
+
+	//! Whether to use the proxy for resolving hostnames
+	bool proxyHostNameLookup;
 };
 
 DLL_PUBLIC LoadPage::LoadErrorHandling strToLoadErrorHandling(const char * s, bool * ok=0);

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -18,7 +18,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with wkhtmltopdf.  If not, see <http://www.gnu.org/licenses/>.
 
-
 #include "multipageloader_p.hh"
 #include <QFile>
 #include <QFileInfo>
@@ -231,12 +230,13 @@ ResourceObject::ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, con
 		proxy.setHostName(settings.proxy.host);
 		proxy.setPort(settings.proxy.port);
 		proxy.setType(settings.proxy.type);
-		// to retrieve a web page, it's not needed to use a fully transparent
-		// http proxy. Moreover, the CONNECT() method is frequently disabled
-		// by proxies administrators.
-		if (settings.proxy.type == QNetworkProxy::HttpProxy)
-			proxy.setCapabilities(QNetworkProxy::CachingCapability |
-			                      QNetworkProxy::TunnelingCapability);
+
+		if (settings.proxy.type == QNetworkProxy::HttpProxy) {
+			QNetworkProxy::Capabilities capabilities = QNetworkProxy::CachingCapability | QNetworkProxy::TunnelingCapability;
+			if (settings.proxyHostNameLookup)
+				capabilities |= QNetworkProxy::HostNameLookupCapability;
+			proxy.setCapabilities(capabilities);
+		}
 		if (!settings.proxy.user.isEmpty())
 			proxy.setUser(settings.proxy.user);
 		if (!settings.proxy.password.isEmpty())

--- a/src/lib/reflect.cc
+++ b/src/lib/reflect.cc
@@ -80,6 +80,7 @@ ReflectImpl<LoadPage>::ReflectImpl(LoadPage & c) {
 	WKHTMLTOPDF_REFLECT(radiobuttonCheckedSvg);
 	WKHTMLTOPDF_REFLECT(cacheDir);
 	WKHTMLTOPDF_REFLECT(bypassProxyForHosts);
+	WKHTMLTOPDF_REFLECT(proxyHostNameLookup);
 }
 
 ReflectImpl<Web>::ReflectImpl(Web & c) {

--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -203,6 +203,7 @@ void CommandLineParserBase::addPageLoadArgs(LoadPage & s) {
 	extended(true);
 	qthack(false);
 	addarg("proxy",'p',"Use a proxy", new ProxySetter(s.proxy, "proxy"));
+	addarg("proxy-hostname-lookup", 0, "Use the proxy for resolving hostnames", new ConstSetter<bool>(s.proxyHostNameLookup, true));
 	addarg("bypass-proxy-for", 0, "Bypass proxy for host (repeatable)", new StringListSetter(s.bypassProxyForHosts, "value"));
 	addarg("username",0,"HTTP Authentication username", new QStrSetter(s.username, "username"));
 	addarg("password",0,"HTTP Authentication password", new QStrSetter(s.password, "password"));


### PR DESCRIPTION
In some environments it's necessary to perform the hostname lookup through the proxy instead of in the application. This PR adds a setting for this.