### PR TITLE
Different margins for the cover page

### DIFF
--- a/include/wkhtmltox/pdfsettings.hh
+++ b/include/wkhtmltox/pdfsettings.hh
@@ -202,6 +202,8 @@ struct DLL_PUBLIC PdfObject {
 
 	bool isTableOfContent;
 
+	bool isCover;
+
 	QString tocXsl;
 
 	QString get(const char * name);

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -991,10 +991,26 @@ void PdfConverterPrivate::printDocument() {
 	progressString = "Preparing";
 	emit out.progressChanged(0);
 
+	qreal leftMargin, topMargin, rightMargin, bottomMargin;
+	printer->getPageMargins(&leftMargin, &topMargin, &rightMargin, &bottomMargin, settings.margin.left.second);
+
 	for (int cc_=0; cc_ < cc; ++cc_) {
 		pageNumber=1;
 		for (int d=0; d < objects.size(); ++d) {
+			if (objects[d].settings.isCover) {
+				painter->save();
+				printer->setPageMargins(leftMargin, 0, rightMargin, 0, settings.margin.left.second);
+				painter->translate(0, -topMargin * printer->height() / printer->heightMM());
+				painter->translate(0, printer->height() / printer->heightMM());
+			}
+
 			beginPrintObject(objects[d]);
+
+			if (objects[d].settings.isCover) {
+				printer->setPageMargins(leftMargin, topMargin, rightMargin, bottomMargin, settings.margin.left.second);
+				painter->restore();
+			}
+
 			// XXX: In some cases nothing gets loaded at all,
 			//      so we would get no webPrinter instance.
 			int pageCount = webPrinter != 0 ? webPrinter->pageCount() : 0;

--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -162,6 +162,7 @@ struct DLL_LOCAL ReflectImpl<PdfObject>: public ReflectClass {
 		WKHTMLTOPDF_REFLECT(includeInOutline);
 		WKHTMLTOPDF_REFLECT(pagesCount);
 		WKHTMLTOPDF_REFLECT(isTableOfContent);
+		WKHTMLTOPDF_REFLECT(isCover);
 		WKHTMLTOPDF_REFLECT(tocXsl);
 	}
 };
@@ -405,6 +406,7 @@ PdfObject::PdfObject():
 	includeInOutline(true),
 	pagesCount(true),
 	isTableOfContent(false),
+	isCover(false),
 	tocXsl("") {};
 
 QString PdfGlobal::get(const char * name) {

--- a/src/lib/pdfsettings.hh
+++ b/src/lib/pdfsettings.hh
@@ -202,6 +202,8 @@ struct DLL_PUBLIC PdfObject {
 
 	bool isTableOfContent;
 
+	bool isCover;
+
 	QString tocXsl;
 
 	QString get(const char * name);

--- a/src/pdf/pdfcommandlineparser.cc
+++ b/src/pdf/pdfcommandlineparser.cc
@@ -178,6 +178,7 @@ void PdfCommandLineParser::parseArguments(int argc, const char ** argv, bool fro
 			ps.header.line = ps.footer.line = false;
 			ps.header.htmlUrl = ps.footer.htmlUrl = "";
 			ps.includeInOutline = false;
+			ps.isCover = true;
 
 			continue;
 		} else if (!strcmp(argv[arg],"toc")) {


### PR DESCRIPTION
Fix for the issue https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3635.
For the proper backward compatibility it probably makes sense to configure this separately with something like --disable-margins-for-cover-page. 