### PR TITLE
Correctly pass the 'copy count' to QPrinter

### DIFF
--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -395,7 +395,7 @@ void PdfConverterPrivate::pagesLoaded(bool ok) {
 
 #ifndef __EXTENSIVE_WKHTMLTOPDF_QT_HACK__
 	//If you do not have the hacks you get this crappy solution
-	printer->setCollateCopies(settings.copies);
+	printer->setCopyCount(settings.copies);
 	printer->setCollateCopies(settings.collate);
 
 	printDocument();


### PR DESCRIPTION
Correctly pass the 'copy count' to QPrinter if QT hacks are not defined.