### PR TITLE
Add options to specify header/footer margin

### DIFF
--- a/include/wkhtmltox/pdfsettings.hh
+++ b/include/wkhtmltox/pdfsettings.hh
@@ -165,6 +165,8 @@ struct DLL_PUBLIC HeaderFooter {
 	QString htmlUrl;
 	//! Spacing
 	float spacing;
+	//! Margin
+	float margin;
 };
 
 struct DLL_PUBLIC PdfObject {

--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -95,6 +95,7 @@
  * - \b header.spacing The amount of space to put between the header and the content, e.g. "1.8". Be
  *      aware that if this is too large the header will be printed outside the pdf document. This
  *      can be corrected with the margin.top setting.
+ * - \b header.margin Top margin
  * - \b header.htmlUrl Url for a HTML document to use for the header.
  *
  * \section pagePdfGlobal Pdf global settings

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -792,12 +792,12 @@ void PdfConverterPrivate::measuringHeadersLoaded(bool ok) {
         PageObject & obj = objects[d];
         if (obj.measuringHeader) {
             // add spacing to prevent moving header out of page
-            obj.headerReserveHeight = calculateHeaderHeight(obj, *obj.measuringHeader) + obj.settings.header.spacing;
+            obj.headerReserveHeight = calculateHeaderHeight(obj, *obj.measuringHeader) + obj.settings.header.spacing + obj.settings.header.margin;
         }
 
         if (obj.measuringFooter) {
             // add spacing to prevent moving footer out of page
-            obj.footerReserveHeight = calculateHeaderHeight(obj, *obj.measuringFooter) + obj.settings.footer.spacing;
+            obj.footerReserveHeight = calculateHeaderHeight(obj, *obj.measuringFooter) + obj.settings.footer.spacing + obj.settings.footer.margin;
         }
     }
 #endif

--- a/src/lib/pdfsettings.cc
+++ b/src/lib/pdfsettings.cc
@@ -143,6 +143,7 @@ struct DLL_LOCAL ReflectImpl<HeaderFooter>: public ReflectClass {
 		WKHTMLTOPDF_REFLECT(line);
 		WKHTMLTOPDF_REFLECT(htmlUrl);
 		WKHTMLTOPDF_REFLECT(spacing);
+		WKHTMLTOPDF_REFLECT(margin);
 	}
 };
 
@@ -361,7 +362,8 @@ HeaderFooter::HeaderFooter():
 	center(""),
 	line(false),
 	htmlUrl(""),
-	spacing(0.0) {}
+	spacing(0.0),
+	margin(0.0) {}
 
 Margin::Margin():
     top(UnitReal(-1,QPrinter::Millimeter)),

--- a/src/lib/pdfsettings.hh
+++ b/src/lib/pdfsettings.hh
@@ -165,6 +165,8 @@ struct DLL_PUBLIC HeaderFooter {
 	QString htmlUrl;
 	//! Spacing
 	float spacing;
+	//! Margin
+	float margin;
 };
 
 struct DLL_PUBLIC PdfObject {

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -277,7 +277,8 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
  	addarg("footer-line",0,"Display line above the footer", new ConstSetter<bool>(od.footer.line,true));
  	addarg("no-footer-line",0,"Do not display line above the footer", new ConstSetter<bool>(od.footer.line,false));
  	addarg("footer-right",0,"Right aligned footer text", new QStrSetter(od.footer.right,"text"));
- 	addarg("footer-spacing",0,"Spacing between footer and content in mm", new FloatSetter(od.footer.spacing,"real"));
+  addarg("footer-spacing",0,"Spacing between footer and content in mm", new FloatSetter(od.footer.spacing,"real"));
+ 	addarg("footer-margin",0,"Footer bottom margin in mm", new FloatSetter(od.footer.margin,"real"));
  	addarg("footer-html",0,"Adds a html footer", new QStrSetter(od.footer.htmlUrl,"url"));
  	addarg("header-center",0,"Centered header text", new QStrSetter(od.header.center,"text"));
  	addarg("header-font-name",0,"Set header font name", new QStrSetter(od.header.fontName,"name"));
@@ -286,7 +287,8 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
  	addarg("header-line",0,"Display line below the header", new ConstSetter<bool>(od.header.line,true));
  	addarg("no-header-line",0,"Do not display line below the header", new ConstSetter<bool>(od.header.line,false));
  	addarg("header-right",0,"Right aligned header text", new QStrSetter(od.header.right,"text"));
- 	addarg("header-spacing",0,"Spacing between header and content in mm", new FloatSetter(od.header.spacing,"real"));
+  addarg("header-spacing",0,"Spacing between header and content in mm", new FloatSetter(od.header.spacing,"real"));
+ 	addarg("header-margin",0,"Header top margin in mm", new FloatSetter(od.header.margin,"real"));
  	addarg("header-html",0,"Adds a html header", new QStrSetter(od.header.htmlUrl,"url"));
 
 	addarg("replace",0, "Replace [name] with value in header and footer (repeatable)", new MapSetter<>(od.replacements, "name", "value"));


### PR DESCRIPTION
The PR adds options `--header-margin` and `--footer-margin` to specify top/bottom margin for header/footer (not to be confused with document top/bottom margin).
This is useful if you have a dynamic header and don't know its size to use `--margin-top` option. So omitting `--margin-top` and using `--header-margin` instead will get the job done. They can be used simultaneously.
Probably it solves this issue https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2940.

I wonder whether it can be solved better than this way. Maybe options can be renamed to better reflect their meaning.