### PR TITLE
Fix application name in libwkhtmltox (bug #3476)

### DIFF
--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -304,6 +304,7 @@ CAPI(int) wkhtmltopdf_init(int use_graphics) {
 		Q_UNUSED(use_graphics);
 #endif
 		a = new QApplication(aa, arg, ug);
+		a->setApplicationName(x);
 		MyLooksStyle * style = new MyLooksStyle();
 		a->setStyle(style);
 	}


### PR DESCRIPTION
Forced setting the right QCoreApplication::applicationName in libwkhtmltox, fixing weird bugs on the User-Agent definition