### PR TITLE
ensure that temp file is cleaned up when using the c bindings

### DIFF
--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -1044,6 +1044,7 @@ void PdfConverterPrivate::printDocument() {
 			fail();
 		}
 		outputData = i.readAll();
+		i.close();
 		tempOut.removeAll();
 	}
 	clearResources();


### PR DESCRIPTION
When using the c bindings to convert to pdf, as done by wrappers such as TuesPechkin, wktemp files were being left behind after conversion due to the temp file not being closed properly.