### PR TITLE
fix TOC and other special pages not present in output PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.12.6 (unreleased)
+--------------------
+* **#3953**: fix TOC and other special pages not present in output PDF (#3962)
+
 v0.12.5 (2018-06-11)
 --------------------
 * fixed build without patched Qt and integrate with Travis CI and AppVeyor

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -887,8 +887,13 @@ void PdfConverterPrivate::beginPrintObject(PageObject & obj) {
 		endPrintObject(objects[obj.number-1]);
 	currentObject = obj.number;
 
+	if (!obj.loaderObject || obj.loaderObject->skip)
+		return;
+
 	QWebPrinter *webPrinter = objects[currentObject].web_printer;
-	if (!obj.loaderObject || obj.loaderObject->skip || webPrinter == 0) return;
+	if (webPrinter == 0)
+		webPrinter = objects[currentObject].web_printer = \
+			new QWebPrinter(obj.page->mainFrame(), printer, *painter);
 
 	QPalette pal = obj.loaderObject->page.palette();
 	pal.setBrush(QPalette::Base, Qt::transparent);


### PR DESCRIPTION
This was a regression introduced in 6f77c4640a760d1297ad4d3441c12b8e9651245a, as the QWebPrinter instance for the TOC and other special pages did not get initialized and hence were skipped from the output.