### PR TITLE
Changed the 'URL' type to 'path'

### DIFF
--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -184,7 +184,7 @@ void CommandLineParserBase::addWebArgs(Web & s) {
  	addarg("disable-plugins",0,"Disable installed plugins", new ConstSetter<bool>(s.enablePlugins,false));
 
 	addarg("minimum-font-size",0,"Minimum font size", new IntSetter(s.minimumFontSize,"int"));
- 	addarg("user-style-sheet",0,"Specify a user style sheet, to load with every page", new QStrSetter(s.userStyleSheet,"url"));
+ 	addarg("user-style-sheet",0,"Specify a user style sheet, to load with every page", new QStrSetter(s.userStyleSheet,"path"));
 	addarg("no-images",0,"Do not load or print images", new ConstSetter<bool>(s.loadImages, false));
 	addarg("images",0,"Do load or print images", new ConstSetter<bool>(s.loadImages, true));
 


### PR DESCRIPTION
Changed the 'URL' type to 'path', because the type 'URL' suggests that a URI can be filled in. However, according to issue #1686, this should be a local file.