### PR TITLE
Correct 'then' to 'than' where appropriate

### DIFF
--- a/docs/libwkhtmltox/pdf_8h.html
+++ b/docs/libwkhtmltox/pdf_8h.html
@@ -319,7 +319,7 @@ int&#160;</td><td class="memItemRight" valign="bottom"><b>phase</b></td></tr>
 </dl>
 <dl class="section return"><dt>Returns</dt><dd>The total number of phases in the conversion process</dd></dl>
 <dl class="section see"><dt>See also</dt><dd>wkhtmltopdf_current_phase, wkhtmltopdf_phase_description</dd></dl>
-<p>Return the largest HTTP code greater then or equal to 300 encountered during loading of any of the supplied objects, if no such error code is found 0 is returned. This function will only return a useful result after wkhtmltopdf_convert has been called.</p>
+<p>Return the largest HTTP code greater than or equal to 300 encountered during loading of any of the supplied objects, if no such error code is found 0 is returned. This function will only return a useful result after wkhtmltopdf_convert has been called.</p>
 <dl class="params"><dt>Parameters</dt><dd>
   <table class="params">
     <tr><td class="paramname">converter</td><td>The converter to query </td></tr>

--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -652,7 +652,7 @@ CAPI(const char *) wkhtmltopdf_progress_string(wkhtmltopdf_converter * converter
 /**
  * \brief Return the largest HTTP error code encountered during conversion
  *
- * Return the largest HTTP code greater then or equal to 300 encountered during loading
+ * Return the largest HTTP code greater than or equal to 300 encountered during loading
  * of any of the supplied objects, if no such error code is found 0 is returned.
  * This function will only return a useful result after \ref wkhtmltopdf_convert has been called.
  *

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -146,7 +146,7 @@ void PdfConverterPrivate::beginConvert() {
 
 #ifndef __EXTENSIVE_WKHTMLTOPDF_QT_HACK__
 	if (objects.size() > 1) {
-		emit out.error("This version of wkhtmltopdf is build against an unpatched version of QT, and does not support more then one input document.");
+		emit out.error("This version of wkhtmltopdf is built against an unpatched version of QT, and does not support more than one input document.");
 		fail();
 		return;
 	}


### PR DESCRIPTION
Minor grammatical update