### PR TITLE
Page Orientation V.2019

### DIFF
--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -948,9 +948,14 @@ void PdfConverterPrivate::beginPrintObject(PageObject & obj) {
 			}
 
 // With the above original code the web printer if !=0 would not hold the Portrait or Landscape resetting
-// Replaced with the below - a forced new webPrinter
+// Replaced with the below - a forced new webPrinter if webPrinter == 0 and Orientation specified
+
   QWebPrinter *webPrinter = objects[currentObject].web_printer;
-	webPrinter = objects[currentObject].web_printer = new QWebPrinter(obj.page->mainFrame(), printer, *painter);
+
+	if (webPrinter == 0 || obj.settings.pageSpecificOrientation != NULL)
+	webPrinter = objects[currentObject].web_printer = \
+	new QWebPrinter(obj.page->mainFrame(), printer, *painter);	
+	
 //
 
 	QPalette pal = obj.loaderObject->page.palette();

--- a/src/lib/pdfsettings.hh
+++ b/src/lib/pdfsettings.hh
@@ -174,6 +174,9 @@ struct DLL_PUBLIC PdfObject {
 
 	QString page;
 
+	//! custom page orientation
+        QString pageSpecificOrientation;
+	
 	//! Header related settings
 	HeaderFooter header;
 

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -228,6 +228,7 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
 
 	section("Page Options");
 	mode(page);
+	addarg("page-orientation",0, "Set Page orientation to (L)andscape or (P)ortrait", new QStrSetter(od.pageSpecificOrientation, "P"));	
  	addarg("default-header",0,"Add a default header, with the name of the page to the left, and the page number to the right, this is short for: --header-left='[webpage]' --header-right='[page]/[toPage]' --top 2cm --header-line", new Caller<DefaultHeaderFunc>());
 
 	addarg("viewport-size", 0, "Set viewport size if you have custom scrollbars or css attribute overflow to emulate window size",new QStrSetter(s.viewportSize,""));


### PR DESCRIPTION
This updated commit adds the necessary code to allow Portrait and Landscape page
changes within a PDF document.

Implemented a new PDF Object parameter --page-orientation with a value of P for portrait and L for landscape.

Given 3 HTML files where you want First Landscape, Second Portrait and Third Landscape invoke as follows:

wkhtmltopdf.exe part_1.htm --page-orientation L part_2.htm --page-orientation P part_3.htm --page-orientation L Output.pdf