### PR TITLE
add debug/info signals, add debug log level, and update JS logging

### DIFF
--- a/src/image/imagearguments.cc
+++ b/src/image/imagearguments.cc
@@ -32,7 +32,7 @@ ImageCommandLineParser::ImageCommandLineParser(wkhtmltopdf::settings::ImageGloba
 	extended(false);
 	qthack(false);
 	addarg("quiet", 'q', "Be less verbose, maintained for backwards compatibility; Same as using --log-level none", new ConstSetter<wkhtmltopdf::settings::LogLevel>(s.logLevel, wkhtmltopdf::settings::None));
-	addarg("log-level", 0, "Set log level to: none, error, warn or info", new LogLevelSetter(s.logLevel, "level"));
+	addarg("log-level", 0, "Set log level to: none, error, warn, info or debug", new LogLevelSetter(s.logLevel, "level"));
 	addarg("width",0,"Set screen width, note that this is used only as a guide line. Use --disable-smart-width to make it strict.", new IntSetter(s.screenWidth,"int"));
 	addarg("height",0,"Set screen height (default is calculated from page content)", new IntSetter(s.screenHeight, "int"));
 	// addarg("scale-w",0,"Set width for resizing", new IntSetter(s.scale.width,"int"));

--- a/src/lib/converter.cc
+++ b/src/lib/converter.cc
@@ -83,6 +83,14 @@ void ConverterPrivate::forwardWarning(QString warning) {
 	emit outer().warning(warning);
 }
 
+void ConverterPrivate::forwardInfo(QString info) {
+	emit outer().info(info);
+}
+
+void ConverterPrivate::forwardDebug(QString debug) {
+	emit outer().debug(debug);
+}
+
 void ConverterPrivate::cancel() {
 	error=true;
 }

--- a/src/lib/converter.hh
+++ b/src/lib/converter.hh
@@ -40,6 +40,8 @@ public:
     QString progressString();
     int httpErrorCode();
 signals:
+    void debug(const QString & message);
+    void info(const QString & message);
     void warning(const QString & message);
     void error(const QString & message);
     void phaseChanged();

--- a/src/lib/converter_p.hh
+++ b/src/lib/converter_p.hh
@@ -57,6 +57,8 @@ public slots:
 	bool convert();
 	void forwardError(QString error);
 	void forwardWarning(QString warning);
+	void forwardInfo(QString info);
+	void forwardDebug(QString debug);
 private:
   friend class Converter;
 };

--- a/src/lib/image.h
+++ b/src/lib/image.h
@@ -51,6 +51,8 @@ CAPI(int) wkhtmltoimage_get_global_setting(wkhtmltoimage_global_settings * setti
 CAPI(wkhtmltoimage_converter *) wkhtmltoimage_create_converter(wkhtmltoimage_global_settings * settings, const char * data);
 CAPI(void) wkhtmltoimage_destroy_converter(wkhtmltoimage_converter * converter);
 
+CAPI(void) wkhtmltoimage_set_debug_callback(wkhtmltoimage_converter * converter, wkhtmltoimage_str_callback cb);
+CAPI(void) wkhtmltoimage_set_info_callback(wkhtmltoimage_converter * converter, wkhtmltoimage_str_callback cb);
 CAPI(void) wkhtmltoimage_set_warning_callback(wkhtmltoimage_converter * converter, wkhtmltoimage_str_callback cb);
 CAPI(void) wkhtmltoimage_set_error_callback(wkhtmltoimage_converter * converter, wkhtmltoimage_str_callback cb);
 CAPI(void) wkhtmltoimage_set_phase_changed_callback(wkhtmltoimage_converter * converter, wkhtmltoimage_void_callback cb);

--- a/src/lib/image_c_bindings_p.hh
+++ b/src/lib/image_c_bindings_p.hh
@@ -30,6 +30,8 @@
 class DLL_LOCAL MyImageConverter: public QObject {
     Q_OBJECT
 public:
+	wkhtmltoimage_str_callback debug_cb;
+	wkhtmltoimage_str_callback info_cb;
 	wkhtmltoimage_str_callback warning_cb;
 	wkhtmltoimage_str_callback error_cb;
 	wkhtmltoimage_void_callback phase_changed;
@@ -43,6 +45,8 @@ public:
 	MyImageConverter(wkhtmltopdf::settings::ImageGlobal * gs, const QString * data);
 	~MyImageConverter();
 public slots:
+    void debug(const QString & message);
+    void info(const QString & message);
     void warning(const QString & message);
     void error(const QString & message);
     void phaseChanged();

--- a/src/lib/imageconverter.cc
+++ b/src/lib/imageconverter.cc
@@ -58,6 +58,8 @@ ImageConverterPrivate::ImageConverterPrivate(ImageConverter & o, wkhtmltopdf::se
 	connect(&loader, SIGNAL(loadFinished(bool)), this, SLOT(pagesLoaded(bool)));
 	connect(&loader, SIGNAL(error(QString)), this, SLOT(forwardError(QString)));
 	connect(&loader, SIGNAL(warning(QString)), this, SLOT(forwardWarning(QString)));
+	connect(&loader, SIGNAL(info(QString)), this, SLOT(forwardInfo(QString)));
+	connect(&loader, SIGNAL(debug(QString)), this, SLOT(forwardDebug(QString)));
 }
 
 void ImageConverterPrivate::beginConvert() {

--- a/src/lib/logging.cc
+++ b/src/lib/logging.cc
@@ -32,6 +32,7 @@ QMap<QString, LogLevel> logLevelMap() {
 	res["error"] = Error;
 	res["warn"] = Warn;
 	res["info"] = Info;
+	res["debug"] = Debug;
 	return res;
 }
 

--- a/src/lib/logging.hh
+++ b/src/lib/logging.hh
@@ -31,7 +31,8 @@ enum LogLevel {
 	None,
 	Error,
 	Warn,
-	Info
+	Info,
+	Debug
 };
 
 DLL_PUBLIC LogLevel strToLogLevel(const char * s, bool * ok=0);

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -72,6 +72,7 @@ void MyNetworkAccessManager::allow(QString path) {
 }
 
 QNetworkReply * MyNetworkAccessManager::createRequest(Operation op, const QNetworkRequest & req, QIODevice * outgoingData) {
+	emit debug(QString("Creating request: ") + req.url().toString());
 
 	if (disposed)
 	{
@@ -156,16 +157,16 @@ QList<QNetworkProxy> MyNetworkProxyFactory::queryProxy (const QNetworkProxyQuery
 MyQWebPage::MyQWebPage(ResourceObject & res): resource(res) {}
 
 void MyQWebPage::javaScriptAlert(QWebFrame *, const QString & msg) {
-	resource.warning(QString("Javascript alert: %1").arg(msg));
+	resource.info(QString("Javascript alert: %1").arg(msg));
 }
 
 bool MyQWebPage::javaScriptConfirm(QWebFrame *, const QString & msg) {
-	resource.warning(QString("Javascript confirm: %1 (answered yes)").arg(msg));
+	resource.info(QString("Javascript confirm: %1 (answered yes)").arg(msg));
 	return true;
 }
 
 bool MyQWebPage::javaScriptPrompt(QWebFrame *, const QString & msg, const QString & defaultValue, QString * result) {
-	resource.warning(QString("Javascript prompt: %1 (answered %2)").arg(msg,defaultValue));
+	resource.info(QString("Javascript prompt: %1 (answered %2)").arg(msg,defaultValue));
 	result = (QString*)&defaultValue;
 	Q_UNUSED(result);
 	return true;
@@ -173,7 +174,7 @@ bool MyQWebPage::javaScriptPrompt(QWebFrame *, const QString & msg, const QStrin
 
 void MyQWebPage::javaScriptConsoleMessage(const QString & message, int lineNumber, const QString & sourceID) {
 	if (resource.settings.debugJavascript)
-		resource.warning(QString("%1:%2 %3").arg(sourceID).arg(lineNumber).arg(message));
+		resource.info(QString("%1:%2 %3").arg(sourceID).arg(lineNumber).arg(message));
 }
 
 bool MyQWebPage::shouldInterruptJavaScript() {
@@ -181,6 +182,7 @@ bool MyQWebPage::shouldInterruptJavaScript() {
 		resource.warning("A slow script was stopped");
 		return true;
 	}
+	resource.debug("A slow script has been detected, but was not stopped");
 	return false;
 }
 
@@ -189,6 +191,7 @@ ResourceObject::ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, con
 	url(u),
 	loginTry(0),
 	progress(0),
+	windowStatusCounter(0),
 	finished(false),
 	signalPrint(false),
 	multiPageLoader(mpl),
@@ -215,6 +218,12 @@ ResourceObject::ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, con
 
 	connect(&networkAccessManager, SIGNAL(finished (QNetworkReply *)),
 			this, SLOT(amfinished (QNetworkReply *) ) );
+
+	connect(&networkAccessManager, SIGNAL(debug(const QString &)),
+			this, SLOT(debug(const QString &)));
+
+	connect(&networkAccessManager, SIGNAL(info(const QString &)),
+			this, SLOT(info(const QString &)));
 
 	connect(&networkAccessManager, SIGNAL(warning(const QString &)),
 			this, SLOT(warning(const QString &)));
@@ -260,6 +269,7 @@ ResourceObject::ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, con
  * Once loading starting, this is called
  */
 void ResourceObject::loadStarted() {
+	debug("QWebPage load started.");
 	if (finished == true) {
 		++multiPageLoader.loading;
 		finished = false;
@@ -291,6 +301,8 @@ void ResourceObject::loadProgress(int p) {
 
 
 void ResourceObject::loadFinished(bool ok) {
+	debug("QWebPage load finished.");
+
 	// If we are finished, this might be a potential bug.
 	if (finished || multiPageLoader.resources.size() <= 0) {
 		warning("A finished ResourceObject received a loading finished signal. "
@@ -325,10 +337,16 @@ void ResourceObject::loadFinished(bool ok) {
 
 void ResourceObject::waitWindowStatus() {
 	QString windowStatus = webPage.mainFrame()->evaluateJavaScript("window.status").toString();
-	//warning(QString("window.status:" + windowStatus + " settings.windowStatus:" + settings.windowStatus));
 	if (windowStatus != settings.windowStatus) {
+		// This is once a second
+		if ((++windowStatusCounter % 20) == 0) {
+			windowStatusCounter = 0;
+			debug(QString("Waiting for window.status; Found: \"" + windowStatus + "\", but expecting: \"" + settings.windowStatus + "\"."));
+		}
+
 		QTimer::singleShot(50, this, SLOT(waitWindowStatus()));
 	} else {
+		debug("Window status \"" + settings.windowStatus + "\" found.");
 		QTimer::singleShot(settings.jsdelay, this, SLOT(loadDone()));
 	}
 }
@@ -341,6 +359,8 @@ void ResourceObject::printRequested(QWebFrame *) {
 void ResourceObject::loadDone() {
 	if (finished) return;
 	finished=true;
+
+	debug("Loading done; Stopping QWebPage and any possible page refreshes.");
 
 	// Ensure no more loading goes..
 	webPage.triggerAction(QWebPage::Stop);
@@ -379,6 +399,14 @@ void ResourceObject::handleAuthenticationRequired(QNetworkReply *reply, QAuthent
 	}
 }
 
+void ResourceObject::debug(const QString & str) {
+	emit multiPageLoader.outer.debug(str);
+}
+
+void ResourceObject::info(const QString & str) {
+	emit multiPageLoader.outer.info(str);
+}
+
 void ResourceObject::warning(const QString & str) {
 	emit multiPageLoader.outer.warning(str);
 }
@@ -392,6 +420,8 @@ void ResourceObject::error(const QString & str) {
  * \param reply The networkreply that has finished
  */
 void ResourceObject::amfinished(QNetworkReply * reply) {
+	debug(QString("Finished request: ") + reply->url().toString());
+
 	int networkStatus = reply->error();
 	int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 	if ((networkStatus != 0 && networkStatus != 5) || (httpStatus > 399 && httpErrorCode == 0))
@@ -793,8 +823,20 @@ void MultiPageLoader::cancel() {
 */
 
 /*!
+  \fn void MultiPageLoader::debug(QString text)
+  \brief Signal emitted when a debug message was generated
+  \param text The debug message
+*/
+
+/*!
+  \fn void MultiPageLoader::info(QString text)
+  \brief Signal emitted when an info message was generated
+  \param text The info message
+*/
+
+/*!
   \fn void MultiPageLoader::warning(QString text)
-  \brief Signal emitted when a none fatal warning has occurred
+  \brief Signal emitted when a non fatal warning has occurred
   \param text A string describing the warning
 */
 

--- a/src/lib/multipageloader.hh
+++ b/src/lib/multipageloader.hh
@@ -63,6 +63,8 @@ signals:
 	void loadFinished(bool ok);
 	void loadProgress(int progress);
 	void loadStarted();
+	void debug(QString text);
+	void info(QString text);
 	void warning(QString text);
 	void error(QString text);
 private:

--- a/src/lib/multipageloader_p.hh
+++ b/src/lib/multipageloader_p.hh
@@ -57,6 +57,8 @@ public:
 	MyNetworkAccessManager(const settings::LoadPage & s);
 	QNetworkReply * createRequest(Operation op, const QNetworkRequest & req, QIODevice * outgoingData = 0);
 signals:
+	void debug(const QString & text);
+	void info(const QString & text);
 	void warning(const QString & text);
 	void error(const QString & text);
 };
@@ -85,6 +87,7 @@ private:
 	QUrl url;
 	int loginTry;
 	int progress;
+	int windowStatusCounter;
 	bool finished;
 	bool signalPrint;
 	MultiPageLoaderPrivate & multiPageLoader;
@@ -103,6 +106,8 @@ public slots:
 	void printRequested(QWebFrame * frame);
 	void loadDone();
 	void handleAuthenticationRequired(QNetworkReply *reply, QAuthenticator *authenticator);
+	void debug(const QString & str);
+	void info(const QString & str);
 	void warning(const QString & str);
 	void error(const QString & str);
 	void sslErrors(QNetworkReply *reply, const QList<QSslError> &);

--- a/src/lib/pdf.h
+++ b/src/lib/pdf.h
@@ -61,6 +61,8 @@ CAPI(int) wkhtmltopdf_get_object_setting(wkhtmltopdf_object_settings * settings,
 CAPI(wkhtmltopdf_converter *) wkhtmltopdf_create_converter(wkhtmltopdf_global_settings * settings);
 CAPI(void) wkhtmltopdf_destroy_converter(wkhtmltopdf_converter * converter);
 
+CAPI(void) wkhtmltopdf_set_debug_callback(wkhtmltopdf_converter * converter, wkhtmltopdf_str_callback cb);
+CAPI(void) wkhtmltopdf_set_info_callback(wkhtmltopdf_converter * converter, wkhtmltopdf_str_callback cb);
 CAPI(void) wkhtmltopdf_set_warning_callback(wkhtmltopdf_converter * converter, wkhtmltopdf_str_callback cb);
 CAPI(void) wkhtmltopdf_set_error_callback(wkhtmltopdf_converter * converter, wkhtmltopdf_str_callback cb);
 CAPI(void) wkhtmltopdf_set_phase_changed_callback(wkhtmltopdf_converter * converter, wkhtmltopdf_void_callback cb);

--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -73,7 +73,8 @@
  * - \b load.blockLocalFileAccess Disallow local and piped files to access other local files. Must
  *      be either "true" or "false".
  * - \b load.stopSlowScript Stop slow running javascript. Must be either "true" or "false".
- * - \b load.debugJavascript Forward javascript warnings and errors to the warning callback.
+ * - \b load.debugJavascript Forward javascript console messages to the info callback.
+ *      Must be either "true" or "false".
  *      Must be either "true" or "false".
  * - \b load.loadErrorHandling How should we handle obejcts that fail to load. Must be one of:
  *      - "abort" Abort the conversion process
@@ -172,12 +173,12 @@
 
 /**
  * \typedef wkhtmltopdf_str_callback
- * \brief Function pointer type used for the error and warning callbacks
+ * \brief Function pointer type used for the error, warning, info and debug callbacks
  *
  * \param converter The converter that issued the callback
- * \param str A utf8 encoded string containing the error or warning message.
+ * \param str A utf8 encoded string containing the error, warning, info or debug message.
  *
- * \sa wkhtmltopdf_set_error_callback, wkhtmltopdf_set_warning_callback
+ * \sa wkhtmltopdf_set_error_callback, wkhtmltopdf_set_warning_callback, wkhtmltopdf_set_info_callback, wkhtmltopdf_set_debug_callback
  */
 
 /**
@@ -208,6 +209,14 @@ using namespace wkhtmltopdf;
 QApplication * a = 0;
 int usage = 0;
 
+void MyPdfConverter::debug(const QString & message) {
+	if (debug_cb && globalSettings->logLevel > settings::Info) (debug_cb)(reinterpret_cast<wkhtmltopdf_converter*>(this), message.toUtf8().constData());
+}
+
+void MyPdfConverter::info(const QString & message) {
+	if (info_cb && globalSettings->logLevel > settings::Warn) (info_cb)(reinterpret_cast<wkhtmltopdf_converter*>(this), message.toUtf8().constData());
+}
+
 void MyPdfConverter::warning(const QString & message) {
 	if (warning_cb && globalSettings->logLevel > settings::Error) (warning_cb)(reinterpret_cast<wkhtmltopdf_converter*>(this), message.toUtf8().constData());
 }
@@ -229,9 +238,11 @@ void MyPdfConverter::finished(bool ok) {
 }
 
 MyPdfConverter::MyPdfConverter(settings::PdfGlobal * gs):
-	warning_cb(0), error_cb(0), phase_changed(0), progress_changed(0), finished_cb(0),
+	debug_cb(0), info_cb(0), warning_cb(0), error_cb(0), phase_changed(0), progress_changed(0), finished_cb(0),
 	converter(*gs), globalSettings(gs) {
 
+    connect(&converter, SIGNAL(debug(const QString &)), this, SLOT(debug(const QString &)));
+    connect(&converter, SIGNAL(info(const QString &)), this, SLOT(info(const QString &)));
     connect(&converter, SIGNAL(warning(const QString &)), this, SLOT(warning(const QString &)));
 	connect(&converter, SIGNAL(error(const QString &)), this, SLOT(error(const QString &)));
 	connect(&converter, SIGNAL(phaseChanged()), this, SLOT(phaseChanged()));
@@ -473,6 +484,28 @@ CAPI(void) wkhtmltopdf_destroy_converter(wkhtmltopdf_converter * converter) {
 }
 
 /**
+ * \brief Set the function that should be called when an debug message is issued during conversion
+ *
+ * \param converter The converter object on which debug messages we want the callback to be called
+ * \param cb The function to call when a debug message is issued
+ *
+ */
+CAPI(void) wkhtmltopdf_set_debug_callback(wkhtmltopdf_converter * converter, wkhtmltopdf_str_callback cb) {
+	reinterpret_cast<MyPdfConverter *>(converter)->debug_cb = cb;
+}
+
+/**
+ * \brief Set the function that should be called when an info message is issued during conversion
+ *
+ * \param converter The converter object on which info messages we want the callback to be called
+ * \param cb The function to call when a info message is issued
+ *
+ */
+CAPI(void) wkhtmltopdf_set_info_callback(wkhtmltopdf_converter * converter, wkhtmltopdf_str_callback cb) {
+	reinterpret_cast<MyPdfConverter *>(converter)->info_cb = cb;
+}
+
+/**
  * \brief Set the function that should be called when an warning message is issued during conversion
  *
  * \param converter The converter object on which warnings we want the callback to be called
@@ -541,7 +574,7 @@ CAPI(void) wkhtmltopdf_set_finished_callback(wkhtmltopdf_converter * converter, 
 /**
  * \brief Convert the input objects into a pdf document
  *
- * This is the main method for the conversion process, during conversion progress information
+ * This is the main method for the conversion process, during conversion progress debug, information,
  * warning, and errors are reported using the supplied call backs. Once the conversion is done
  * the output pdf (or ps) file will be placed at the location of the "out" setting supplied in
  * the global settings object during construction of the converter. If this setting is not supplied

--- a/src/lib/pdf_c_bindings_p.hh
+++ b/src/lib/pdf_c_bindings_p.hh
@@ -32,6 +32,8 @@
 class DLL_LOCAL MyPdfConverter: public QObject {
     Q_OBJECT
 public:
+	wkhtmltopdf_str_callback debug_cb;
+	wkhtmltopdf_str_callback info_cb;
 	wkhtmltopdf_str_callback warning_cb;
 	wkhtmltopdf_str_callback error_cb;
 	wkhtmltopdf_void_callback phase_changed;
@@ -47,6 +49,8 @@ public:
 	MyPdfConverter(wkhtmltopdf::settings::PdfGlobal * gs);
 	~MyPdfConverter();
 public slots:
+    void debug(const QString & message);
+    void info(const QString & message);
     void warning(const QString & message);
     void error(const QString & message);
     void phaseChanged();

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -101,27 +101,37 @@ PdfConverterPrivate::PdfConverterPrivate(PdfGlobal & s, PdfConverter & o) :
 	connect(&pageLoader, SIGNAL(loadFinished(bool)), this, SLOT(pagesLoaded(bool)));
 	connect(&pageLoader, SIGNAL(error(QString)), this, SLOT(forwardError(QString)));
 	connect(&pageLoader, SIGNAL(warning(QString)), this, SLOT(forwardWarning(QString)));
+	connect(&pageLoader, SIGNAL(info(QString)), this, SLOT(forwardInfo(QString)));
+	connect(&pageLoader, SIGNAL(debug(QString)), this, SLOT(forwardDebug(QString)));
 
 #ifdef __EXTENSIVE_WKHTMLTOPDF_QT_HACK__
     connect(&measuringHFLoader, SIGNAL(loadProgress(int)), this, SLOT(loadProgress(int)));
     connect(&measuringHFLoader, SIGNAL(loadFinished(bool)), this, SLOT(measuringHeadersLoaded(bool)));
     connect(&measuringHFLoader, SIGNAL(error(QString)), this, SLOT(forwardError(QString)));
     connect(&measuringHFLoader, SIGNAL(warning(QString)), this, SLOT(forwardWarning(QString)));
+    connect(&measuringHFLoader, SIGNAL(info(QString)), this, SLOT(forwardInfo(QString)));
+    connect(&measuringHFLoader, SIGNAL(debug(QString)), this, SLOT(forwardDebug(QString)));
 
     connect(&hfLoader, SIGNAL(loadProgress(int)), this, SLOT(loadProgress(int)));
 	connect(&hfLoader, SIGNAL(loadFinished(bool)), this, SLOT(headersLoaded(bool)));
 	connect(&hfLoader, SIGNAL(error(QString)), this, SLOT(forwardError(QString)));
 	connect(&hfLoader, SIGNAL(warning(QString)), this, SLOT(forwardWarning(QString)));
+	connect(&hfLoader, SIGNAL(info(QString)), this, SLOT(forwardInfo(QString)));
+	connect(&hfLoader, SIGNAL(debug(QString)), this, SLOT(forwardDebug(QString)));
 
     connect(&tocLoader1, SIGNAL(loadProgress(int)), this, SLOT(loadProgress(int)));
 	connect(&tocLoader1, SIGNAL(loadFinished(bool)), this, SLOT(tocLoaded(bool)));
 	connect(&tocLoader1, SIGNAL(error(QString)), this, SLOT(forwardError(QString)));
 	connect(&tocLoader1, SIGNAL(warning(QString)), this, SLOT(forwardWarning(QString)));
+	connect(&tocLoader1, SIGNAL(info(QString)), this, SLOT(forwardInfo(QString)));
+	connect(&tocLoader1, SIGNAL(debug(QString)), this, SLOT(forwardDebug(QString)));
 
 	connect(&tocLoader2, SIGNAL(loadProgress(int)), this, SLOT(loadProgress(int)));
 	connect(&tocLoader2, SIGNAL(loadFinished(bool)), this, SLOT(tocLoaded(bool)));
 	connect(&tocLoader2, SIGNAL(error(QString)), this, SLOT(forwardError(QString)));
 	connect(&tocLoader2, SIGNAL(warning(QString)), this, SLOT(forwardWarning(QString)));
+	connect(&tocLoader2, SIGNAL(info(QString)), this, SLOT(forwardInfo(QString)));
+	connect(&tocLoader2, SIGNAL(debug(QString)), this, SLOT(forwardDebug(QString)));
 #endif
 
 	if ( ! settings.viewportSize.isEmpty())
@@ -1159,6 +1169,18 @@ const settings::PdfGlobal & PdfConverter::globalSettings() const {
 	return d->settings;
 }
 
+
+/*!
+  \fn PdfConverter::debug(const QString & message)
+  \brief Signal emitted when a debug message was generated
+  \param message The debug message
+*/
+
+/*!
+  \fn PdfConverter::info(const QString & message)
+  \brief Signal emitted when a info message was generated
+  \param message The info message
+*/
 
 /*!
   \fn PdfConverter::warning(const QString & message)

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -177,7 +177,7 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
 	qthack(false);
 
 	addarg("quiet", 'q', "Be less verbose, maintained for backwards compatibility; Same as using --log-level none", new ConstSetter<LogLevel>(s.logLevel, None));
-	addarg("log-level", 0, "Set log level to: none, error, warn or info", new LogLevelSetter(s.logLevel, "level"));
+	addarg("log-level", 0, "Set log level to: none, error, warn, info or debug", new LogLevelSetter(s.logLevel, "level"));
 
 	addarg("no-collate", 0, "Do not collate when printing multiple copies", new ConstSetter<bool>(s.collate, false));
 	addarg("collate", 0, "Collate when printing multiple copies", new ConstSetter<bool>(s.collate, true));

--- a/src/shared/commonarguments.cc
+++ b/src/shared/commonarguments.cc
@@ -230,8 +230,8 @@ void CommandLineParserBase::addPageLoadArgs(LoadPage & s) {
 
 	addarg("cache-dir", 0, "Web cache directory", new QStrSetter(s.cacheDir,"path"));
 
-	addarg("debug-javascript", 0,"Show javascript debugging output", new ConstSetter<bool>(s.debugJavascript, true));
-	addarg("no-debug-javascript", 0,"Do not show javascript debugging output", new ConstSetter<bool>(s.debugJavascript, false));
+	addarg("debug-javascript", 0,"Show javascript console output", new ConstSetter<bool>(s.debugJavascript, true));
+	addarg("no-debug-javascript", 0,"Do not show javascript console output", new ConstSetter<bool>(s.debugJavascript, false));
 	addarg("stop-slow-scripts", 0, "Stop slow running javascripts", new ConstSetter<bool>(s.stopSlowScripts, true));
 	addarg("no-stop-slow-scripts", 0, "Do not Stop slow running javascripts", new ConstSetter<bool>(s.stopSlowScripts, false));
 	addarg("run-script", 0, "Run this additional javascript after the page is done loading (repeatable)", new StringListSetter(s.runScript, "js"));

--- a/src/shared/progressfeedback.cc
+++ b/src/shared/progressfeedback.cc
@@ -33,6 +33,34 @@ namespace wkhtmltopdf {
 
 #define S(t) ((t).toLocal8Bit().constData())
 
+void ProgressFeedback::finishLine(int start) {
+	for (; start < lw; ++start)
+		fprintf(stderr, " ");
+	fprintf(stderr, "\n");
+	lw = 0;
+	fflush(stderr);
+}
+
+/*!
+  \brief Write out a debug message
+  \param message The debug message
+*/
+void ProgressFeedback::debug(const QString &message) {
+	if (logLevel < settings::Debug) return;
+	fprintf(stderr, "Debug: %s",S(message));
+	finishLine(7 + message.size());
+}
+
+/*!
+  \brief Write out a info message
+  \param message The info message
+*/
+void ProgressFeedback::info(const QString &message) {
+	if (logLevel < settings::Info) return;
+	fprintf(stderr, "Info: %s",S(message));
+	finishLine(6 + message.size());
+}
+
 /*!
   \brief Write out a warning message
   \param message The warning message
@@ -40,11 +68,7 @@ namespace wkhtmltopdf {
 void ProgressFeedback::warning(const QString &message) {
 	if (logLevel < settings::Warn) return;
 	fprintf(stderr, "Warning: %s",S(message));
-	for (int l = 9 + message.size(); l < lw; ++l)
-		fprintf(stderr, " ");
-	fprintf(stderr, "\n");
-	lw = 0;
-	fflush(stderr);
+	finishLine(9 + message.size());
 }
 
 /*!
@@ -54,11 +78,7 @@ void ProgressFeedback::warning(const QString &message) {
 void ProgressFeedback::error(const QString &message) {
 	if (logLevel < settings::Error) return;
 	fprintf(stderr, "Error: %s",S(message));
-	for (int l = 7 + message.size(); l < lw; ++l)
-		fprintf(stderr, " ");
-	fprintf(stderr, "\n");
-	lw = 0;
-	fflush(stderr);
+	finishLine(7 + message.size());
 }
 
 /*!
@@ -104,6 +124,8 @@ void ProgressFeedback::progressChanged(int progress) {
 
 ProgressFeedback::ProgressFeedback(settings::LogLevel l, Converter & _):
     logLevel(l), converter(_), lw(0) {
+    connect(&converter, SIGNAL(debug(const QString &)), this, SLOT(debug(const QString &)));
+    connect(&converter, SIGNAL(info(const QString &)), this, SLOT(info(const QString &)));
     connect(&converter, SIGNAL(warning(const QString &)), this, SLOT(warning(const QString &)));
 	connect(&converter, SIGNAL(error(const QString &)), this, SLOT(error(const QString &)));
 	connect(&converter, SIGNAL(phaseChanged()), this, SLOT(phaseChanged()));

--- a/src/shared/progressfeedback.hh
+++ b/src/shared/progressfeedback.hh
@@ -30,7 +30,10 @@ private:
 	settings::LogLevel logLevel;
 	Converter & converter;
 	int lw;
+	void finishLine(int start);
 public slots:
+	void debug(const QString &message);
+	void info(const QString &message);
 	void warning(const QString &message);
 	void error(const QString &message);
 	void phaseChanged();


### PR DESCRIPTION
- add and connect debug and info signals across the project
- add a debug log level
- add a `--debug-network-requests` flag
- emit JavaScript console messages as INFO rather than WARNING
- add additional debugging output (on regardless of `--debug-network-requests`, which just enables even more debugging output)