### PR TITLE
Make printMediaType a load-time setting

### DIFF
--- a/src/lib/converter.cc
+++ b/src/lib/converter.cc
@@ -43,7 +43,6 @@ void ConverterPrivate::updateWebSettings(QWebSettings * ws, const settings::Web 
 		ws->setPrintingMaximumShrinkFactor(1.0);
 		ws->setPrintingMinimumShrinkFactor(1.0);
 	}
-	ws->setPrintingMediaType(s.printMediaType?"print":"screen");
 #endif
 	ws->setAttribute(QWebSettings::JavaEnabled, s.enablePlugins);
 	ws->setAttribute(QWebSettings::JavascriptEnabled, s.enableJavascript);

--- a/src/lib/loadsettings.cc
+++ b/src/lib/loadsettings.cc
@@ -146,6 +146,7 @@ LoadPage::LoadPage():
 	loadErrorHandling(abort),
 	mediaLoadErrorHandling(ignore),
 	cacheDir(""),
+	printMediaType(false),
 	proxyHostNameLookup(false) {};
 
 }

--- a/src/lib/loadsettings.hh
+++ b/src/lib/loadsettings.hh
@@ -135,6 +135,9 @@ struct DLL_PUBLIC LoadPage {
 
 	//! Whether to use the proxy for resolving hostnames
 	bool proxyHostNameLookup;
+
+	//! Should we use the print or the screen media type
+	bool printMediaType;
 };
 
 DLL_PUBLIC LoadPage::LoadErrorHandling strToLoadErrorHandling(const char * s, bool * ok=0);

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -184,6 +184,11 @@ bool MyQWebPage::shouldInterruptJavaScript() {
 	return false;
 }
 
+QString MyQWebPage::overrideMediaType() const
+{
+    return resource.settings.printMediaType ? "print" : "screen";
+}
+
 ResourceObject::ResourceObject(MultiPageLoaderPrivate & mpl, const QUrl & u, const settings::LoadPage & s):
 	networkAccessManager(s),
 	url(u),

--- a/src/lib/multipageloader_p.hh
+++ b/src/lib/multipageloader_p.hh
@@ -74,6 +74,7 @@ public:
 	virtual bool javaScriptConfirm(QWebFrame * frame, const QString & msg);
 	virtual bool javaScriptPrompt(QWebFrame * frame, const QString & msg, const QString & defaultValue, QString * result);
 	virtual void javaScriptConsoleMessage(const QString & message, int lineNumber, const QString & sourceID);
+	virtual QString overrideMediaType() const;
 public slots:
 	bool shouldInterruptJavaScript();
 };

--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -49,8 +49,6 @@
  * - \b web.enableIntelligentShrinking Should we enable intelligent shrinkng to fit more content
  *      on one page? Must be either "true" or "false". Has no effect for wkhtmltoimage.
  * - \b web.minimumFontSize The minimum font size allowed. E.g. "9"
- * - \b web.printMediaType Should the content be printed using the print media type instead
- *      of the screen media type. Must be either "true" or "false". Has no effect for wkhtmltoimage.
  * - \b web.defaultEncoding What encoding should we guess content is using if they do not
  *      specify it properly? E.g. "utf-8"
  * - \b web.userStyleSheet Url er path to a user specified style sheet.
@@ -81,6 +79,8 @@
  *      - "ignore" Try to add the object to the final output.
  * - \b load.proxy String describing what proxy to use when loading the object.
  * - \b load.runScript TODO
+ * - \b load.printMediaType Should the content be printed using the print media type instead
+ *      of the screen media type. Must be either "true" or "false". Has no effect for wkhtmltoimage.
  *
  * \section pageHeaderFooter Header and footer settings
  * The same settings can be applied for headers and footers, here there are explained in
@@ -423,6 +423,9 @@ CAPI(void) wkhtmltopdf_destroy_object_settings(wkhtmltopdf_object_settings * obj
  * \returns 1 if the setting was updated successfully and 0 otherwise.
  */
 CAPI(int) wkhtmltopdf_set_object_setting(wkhtmltopdf_object_settings * settings, const char * name, const char * value) {
+	if (!strcmp(name, "web.printMediaType")) {
+		name = "load.printMediaType";
+	}
 	return reinterpret_cast<settings::PdfObject *>(settings)->set(name, QString::fromUtf8(value));
 }
 

--- a/src/lib/reflect.cc
+++ b/src/lib/reflect.cc
@@ -81,6 +81,7 @@ ReflectImpl<LoadPage>::ReflectImpl(LoadPage & c) {
 	WKHTMLTOPDF_REFLECT(cacheDir);
 	WKHTMLTOPDF_REFLECT(bypassProxyForHosts);
 	WKHTMLTOPDF_REFLECT(proxyHostNameLookup);
+	WKHTMLTOPDF_REFLECT(printMediaType);
 }
 
 ReflectImpl<Web>::ReflectImpl(Web & c) {
@@ -89,7 +90,6 @@ ReflectImpl<Web>::ReflectImpl(Web & c) {
 	WKHTMLTOPDF_REFLECT(enableJavascript);
 	WKHTMLTOPDF_REFLECT(enableIntelligentShrinking);
 	WKHTMLTOPDF_REFLECT(minimumFontSize);
-	WKHTMLTOPDF_REFLECT(printMediaType);
 	WKHTMLTOPDF_REFLECT(defaultEncoding);
 	WKHTMLTOPDF_REFLECT(userStyleSheet);
 	WKHTMLTOPDF_REFLECT(enablePlugins);

--- a/src/lib/websettings.cc
+++ b/src/lib/websettings.cc
@@ -29,7 +29,6 @@ Web::Web() :
 	enableJavascript(true),
 	enableIntelligentShrinking(true),
 	minimumFontSize(-1),
-	printMediaType(false),
 	defaultEncoding(""),
 	userStyleSheet(""),
 	enablePlugins(false) {}

--- a/src/lib/websettings.hh
+++ b/src/lib/websettings.hh
@@ -46,9 +46,6 @@ struct DLL_PUBLIC Web {
 	//! Minimum font size
 	int minimumFontSize;
 
-	//! Should we use the print or the screen media type
-	bool printMediaType;
-
 	//! Encoding used to enterpit a document with do supplied encoding
 	QString defaultEncoding;
 

--- a/src/pdf/pdfarguments.cc
+++ b/src/pdf/pdfarguments.cc
@@ -247,8 +247,8 @@ PdfCommandLineParser::PdfCommandLineParser(PdfGlobal & s, QList<PdfObject> & ps)
 
 	extended(false);
  	qthack(true);
-	addarg("print-media-type",0,"Use print media-type instead of screen", new ConstSetter<bool>(od.web.printMediaType,true));
-	addarg("no-print-media-type",0,"Do not use print media-type instead of screen", new ConstSetter<bool>(od.web.printMediaType, false));
+	addarg("print-media-type",0,"Use print media-type instead of screen", new ConstSetter<bool>(od.load.printMediaType,true));
+	addarg("no-print-media-type",0,"Do not use print media-type instead of screen", new ConstSetter<bool>(od.load.printMediaType, false));
 
  	extended(true);
  	qthack(true);


### PR DESCRIPTION
This guarantees that images referenced only within @media print { }
are loaded when using --print-media-type. An additional benefit is
that images for irrelevant media types won't be loaded, only to be
discarded at printing time.

This fixes https://github.com/wkhtmltopdf/wkhtmltopdf/issues/4674