### PR TITLE
Fix header height calculation causing blank space before

### DIFF
--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -46,7 +46,7 @@ using namespace wkhtmltopdf::settings;
 #define STRINGIZE_(x) #x
 #define STRINGIZE(x) STRINGIZE_(x)
 
-const qreal PdfConverter::millimeterToPointMultiplier = 2.83464567;
+const qreal PdfConverter::millimeterToPointMultiplier = 3.779527559;
 
 DLL_LOCAL QMap<QWebPage *, PageObject *> PageObject::webPageToObject;
 


### PR DESCRIPTION
Hello,

I tried to make a fix for issue #3974, this should fix the blank space above the header when using --header-html
I change the way you calculate the height to use this formula : (pixel x inch in mm) / dpi
I test with the example that DaveWishesHe provided in the issue and with some case we had at work, it seems to work great.