### PR TITLE
chore: add aws lambda image to downloads

### DIFF
--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -244,4 +244,11 @@ You'll need to extract the distribution-specific package, bundle it with necessa
 This is a false positive reported because Symantec has not seen this file before -- see [this clarification](http://community.norton.com/forums/clarification-wsreputation1-detection) for details.
 
 #### How do I use it with [AWS Lambda](https://aws.amazon.com/lambda/) setups?
-All files required for lambda layer are packed in one zip archive ([layer](https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-4/wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip)).
+All files required for lambda layer are packed in one zip archive ([layer](https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-4/wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip)). You may test it locally by unpacking the archive and running next commands:
+```bash
+$ docker run --rm -it -v$PWD/lambda:/opt amazonlinux:2
+bash-4.2# LD_LIBRARY_PATH=/opt/lib FONTCONFIG_PATH=/opt/fonts /opt/bin/wkhtmltopdf https://google.com/ /opt/google.pdf
+```
+After that you may find a pdf file generated from google home page in you `layer` directory.
+
+To use `wkhtmltox` in your lambda function you may put the content of the archive together with your lambda function or create a [layer](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html). Don't forget to provide environment variable for fontconfig (`FONTCONFIG_PATH=/opt/fonts`).

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -244,9 +244,9 @@ You'll need to extract the distribution-specific package, bundle it with necessa
 This is a false positive reported because Symantec has not seen this file before -- see [this clarification](http://community.norton.com/forums/clarification-wsreputation1-detection) for details.
 
 #### How do I use it with [AWS Lambda](https://aws.amazon.com/lambda/) setups?
-All files required for lambda layer are packed in one zip archive ([wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip](https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-4/wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip)). You may test it locally by unpacking the archive and running next commands:
+All files required for lambda layer are packed in one zip archive ([wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip](https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-4/wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip)). You may test it locally by unpacking the archive into the `layer` directory and running next commands:
 ```bash
-$ docker run --rm -it -v$PWD/lambda:/opt amazonlinux:2
+$ docker run --rm -it -v$PWD/layer:/opt amazonlinux:2
 bash-4.2# LD_LIBRARY_PATH=/opt/lib FONTCONFIG_PATH=/opt/fonts /opt/bin/wkhtmltopdf https://google.com/ /opt/google.pdf
 ```
 After that, you may find a pdf file generated from the google home page in your `layer` directory.

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -244,7 +244,7 @@ You'll need to extract the distribution-specific package, bundle it with necessa
 This is a false positive reported because Symantec has not seen this file before -- see [this clarification](http://community.norton.com/forums/clarification-wsreputation1-detection) for details.
 
 #### How do I use it with [AWS Lambda](https://aws.amazon.com/lambda/) setups?
-All files required for lambda layer are packed in one zip archive ([layer](https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-4/wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip)). You may test it locally by unpacking the archive and running next commands:
+All files required for lambda layer are packed in one zip archive ([wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip](https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-4/wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip)). You may test it locally by unpacking the archive and running next commands:
 ```bash
 $ docker run --rm -it -v$PWD/lambda:/opt amazonlinux:2
 bash-4.2# LD_LIBRARY_PATH=/opt/lib FONTCONFIG_PATH=/opt/fonts /opt/bin/wkhtmltopdf https://google.com/ /opt/google.pdf

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -154,6 +154,14 @@ The current stable series is **0.12.6**, which was released on June 11, 2020 -- 
             <td colspan="2">&nbsp;</td>
         </tr>
         <tr>
+            <td><a href="https://aws.amazon.com/amazon-linux-2/">Amazon Linux Lambda</a></td>
+            <td>2</td>
+            <td>
+                <a href="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-4/wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip">x86_64</a>
+            </td>
+            <td colspan="4">&nbsp;</td>
+        </tr>
+        <tr>
             <td><a href="https://software.opensuse.org/distributions/leap">openSUSE Leap</a></td>
             <td>15</td>
             <td>
@@ -182,21 +190,21 @@ All of the above packages were [produced automatically via Azure Pipelines](http
 
 Please note that bug reports **will not be accepted** against the following, which are considered obsolete. It is recommended to use the latest stable release instead, and report an issue if there is a regression from a previous release.
 
-Date       | Release
-----       | -------
-2018-06-11 | [0.12.5](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.5/)
-2019-04-30 | [0.12.1.4](https://github.com/wkhtmltopdf/packaging/releases/0.12.1.4-2/) (linux-only)
-2016-11-22 | [0.12.4](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.4/)
-2016-03-02 | [0.12.3.2](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.3.2/) (windows-only)
-2016-01-30 | [0.12.3.1](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.3.1/) (windows-only)
-2016-01-20 | [0.12.3](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.3/)
-2015-07-12 | [0.12.2.4](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.2.4/) (windows-only)
-2015-06-20 | [0.12.2.3](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.2.3/) (windows-only)
-2015-04-06 | [0.12.2.2](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.2.2/) (windows-only)
-2015-01-19 | [0.12.2.1](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.2.1/)
-2015-01-09 | [0.12.2](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.2/)
-2014-06-26 | [0.12.1](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.1/)
-2014-02-06 | [0.12.0](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.0/)
+| Date       | Release                                                                                  |
+| ---------- | ---------------------------------------------------------------------------------------- |
+| 2018-06-11 | [0.12.5](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.5/)                    |
+| 2019-04-30 | [0.12.1.4](https://github.com/wkhtmltopdf/packaging/releases/0.12.1.4-2/) (linux-only)   |
+| 2016-11-22 | [0.12.4](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.4/)                    |
+| 2016-03-02 | [0.12.3.2](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.3.2/) (windows-only) |
+| 2016-01-30 | [0.12.3.1](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.3.1/) (windows-only) |
+| 2016-01-20 | [0.12.3](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.3/)                    |
+| 2015-07-12 | [0.12.2.4](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.2.4/) (windows-only) |
+| 2015-06-20 | [0.12.2.3](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.2.3/) (windows-only) |
+| 2015-04-06 | [0.12.2.2](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.2.2/) (windows-only) |
+| 2015-01-19 | [0.12.2.1](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.2.1/)                |
+| 2015-01-09 | [0.12.2](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.2/)                    |
+| 2014-06-26 | [0.12.1](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.1/)                    |
+| 2014-02-06 | [0.12.0](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.0/)                    |
 
 If you need versions older than `0.12.0`, you can look at the [obsolete downloads](https://github.com/wkhtmltopdf/obsolete-downloads/blob/master/README.md).
 
@@ -234,3 +242,6 @@ You'll need to extract the distribution-specific package, bundle it with necessa
 #### Symantec reports a virus `WS.Reputation.1` for the Windows builds
 
 This is a false positive reported because Symantec has not seen this file before -- see [this clarification](http://community.norton.com/forums/clarification-wsreputation1-detection) for details.
+
+#### How do I use it with [AWS Lambda](https://aws.amazon.com/lambda/) setups?
+All files required for lambda layer are packed in one zip archive ([layer](https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-4/wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip)).

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -205,13 +205,13 @@ If you need versions older than `0.12.0`, you can look at the [obsolete download
 
 ## FAQ
 
-#### Why do you have static builds with patched Qt?
+### Why do you have static builds with patched Qt?
 
 Good question. Some features require you to use a patched Qt, because those aren't yet upstream -- please read the [project status](status.html) for a longer explanation.
 
 Most Linux distributions (_quite understandably_) would prefer that this project upstreamed the patches, and choose to compile without those features. This leads to quite different behavior -- you get a later web engine, but behavior can vary from distribution to distribution.
 
-#### Why are there no "generic" Linux builds (_which were provided earlier_)?
+### Why are there no "generic" Linux builds (_which were provided earlier_)?
 
 Although the builds are static, it is very important to understand what it means in the context of Qt -- on which wkhtmltopdf is built. A static build means that _only_ Qt is linked in this manner -- the remaining system packages still need to be installed. Over a period of time, major areas of divergence between distributions were found by trial and error:
 

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -252,3 +252,21 @@ bash-4.2# LD_LIBRARY_PATH=/opt/lib FONTCONFIG_PATH=/opt/fonts /opt/bin/wkhtmltop
 After that, you may find a pdf file generated from the google home page in your `layer` directory.
 
 To use `wkhtmltox` in your lambda function you may put the content of the archive together with your lambda function or create a [layer](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html). Don't forget to provide an environment variable for `fontconfig` (`FONTCONFIG_PATH=/opt/fonts`).
+
+In case you use Serverless framework you may add the next lines to your `serverless.yml` file:
+```yaml
+layers:
+  wkhtmltoxLayer:
+    name: wkhtmltox
+    description: wkhtmltox binaries for pdf/image generation
+    package:
+      artifact: wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip
+
+functions:
+    PdfGenerator:
+        handler: generatePdf.handler
+        layers:
+        - { Ref: WkhtmltoxLayerLambdaLayer }
+        environment:
+            FONTCONFIG_PATH: /opt/fonts
+```

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -257,7 +257,7 @@ functions:
     PdfGenerator:
         handler: generatePdf.handler
         layers:
-        - { Ref: WkhtmltoxLayerLambdaLayer }
+            - { Ref: WkhtmltoxLayerLambdaLayer }
         environment:
             FONTCONFIG_PATH: /opt/fonts
 ```

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -151,15 +151,10 @@ The current stable series is **0.12.6**, which was released on June 11, 2020 -- 
              </td><td>&nbsp;</td><td>
                 <a href="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox-0.12.6-1.amazonlinux2.aarch64.rpm">aarch64</a>
             </td>
-            <td colspan="2">&nbsp;</td>
-        </tr>
-        <tr>
-            <td><a href="https://aws.amazon.com/amazon-linux-2/">Amazon Linux Lambda</a></td>
-            <td>2</td>
+            <td>&nbsp;</td>
             <td>
-                <a href="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-4/wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip">x86_64</a>
+                <a href="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-4/wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip">lambda zip</a>
             </td>
-            <td colspan="4">&nbsp;</td>
         </tr>
         <tr>
             <td><a href="https://software.opensuse.org/distributions/leap">openSUSE Leap</a></td>

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -249,6 +249,6 @@ All files required for lambda layer are packed in one zip archive ([layer](https
 $ docker run --rm -it -v$PWD/lambda:/opt amazonlinux:2
 bash-4.2# LD_LIBRARY_PATH=/opt/lib FONTCONFIG_PATH=/opt/fonts /opt/bin/wkhtmltopdf https://google.com/ /opt/google.pdf
 ```
-After that you may find a pdf file generated from google home page in you `layer` directory.
+After that, you may find a pdf file generated from the google home page in your `layer` directory.
 
-To use `wkhtmltox` in your lambda function you may put the content of the archive together with your lambda function or create a [layer](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html). Don't forget to provide environment variable for fontconfig (`FONTCONFIG_PATH=/opt/fonts`).
+To use `wkhtmltox` in your lambda function you may put the content of the archive together with your lambda function or create a [layer](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html). Don't forget to provide an environment variable for `fontconfig` (`FONTCONFIG_PATH=/opt/fonts`).

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -221,7 +221,7 @@ Although the builds are static, it is very important to understand what it means
 
 While Python has also tried to do this using [manylinux](https://github.com/pypa/manylinux) -- it doesn't always work well (e.g. `alpine` is _not_ recommended with binary wheels if you google for it), and requires you to statically link everything. This may work for them, but wkhtmltopdf also depends on the runtime configuration on actual fonts installed (i.e. `fontconfig` and `freetype2`). It's not possible to abstract everything out and test/fix everything for every OS/distribution with the limited resources this project has -- it makes more sense to make distribution-specific versions which are almost guaranteed to work, as they use the specific versions that the distribution has packaged.
 
-#### I don't see an appropriate download for my platform!
+### I don't see an appropriate download for my platform!
 
 If the distribution you are using is listed:
   * but not the specific patch release -- try it, as it's very likely to work regardless.
@@ -230,16 +230,12 @@ If the distribution you are using is listed:
 
 Head over to the [packaging repository](https://github.com/wkhtmltopdf/packaging) and start a discussion if your platform isn't listed.
 
-#### How do I use it with [FaaS](https://en.wikipedia.org/wiki/Function_as_a_service) setups?
+### How do I use it with [FaaS](https://en.wikipedia.org/wiki/Function_as_a_service) setups?
 
-You'll need to extract the distribution-specific package, bundle it with necessary libraries, configuration and/or fonts and then upload it. See [this ticket](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/4523) for AWS Lambda and [this StackOverflow question](https://stackoverflow.com/q/46639273) for Google Cloud Functions. PRs are welcome to expand this section, if you have more information about this -- this is not a setup that the maintainer uses 😄
+You'll need to extract the distribution-specific package, bundle it with necessary libraries, configuration and/or fonts and then upload it. See [this StackOverflow question](https://stackoverflow.com/q/46639273) for Google Cloud Functions. PRs are welcome to expand this section, if you have more information about this -- this is not a setup that the maintainer uses 😄
 
-#### Symantec reports a virus `WS.Reputation.1` for the Windows builds
-
-This is a false positive reported because Symantec has not seen this file before -- see [this clarification](http://community.norton.com/forums/clarification-wsreputation1-detection) for details.
-
-#### How do I use it with [AWS Lambda](https://aws.amazon.com/lambda/) setups?
-All files required for lambda layer are packed in one zip archive ([wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip](https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-4/wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip)). You may test it locally by unpacking the archive into the `layer` directory and running next commands:
+#### How do I use it in [AWS Lambda](https://aws.amazon.com/lambda/)?
+All files required for lambda layer are packed in one zip archive (Amazon Linux 2 / lambda zip). You may test it locally by unpacking the archive into the `layer` directory and running next commands:
 ```bash
 $ docker run --rm -it -v$PWD/layer:/opt amazonlinux:2
 bash-4.2# LD_LIBRARY_PATH=/opt/lib FONTCONFIG_PATH=/opt/fonts /opt/bin/wkhtmltopdf https://google.com/ /opt/google.pdf
@@ -255,7 +251,7 @@ layers:
     name: wkhtmltox
     description: wkhtmltox binaries for pdf/image generation
     package:
-      artifact: wkhtmltox-0.12.6-4.amazonlinux2_lambda.zip
+      artifact: wkhtmltox-x.xx.xxx.amazonlinux2_lambda.zip
 
 functions:
     PdfGenerator:
@@ -265,3 +261,7 @@ functions:
         environment:
             FONTCONFIG_PATH: /opt/fonts
 ```
+
+### Symantec reports a virus `WS.Reputation.1` for the Windows builds
+
+This is a false positive reported because Symantec has not seen this file before -- see [this clarification](http://community.norton.com/forums/clarification-wsreputation1-detection) for details.


### PR DESCRIPTION
I added a link to the build suitable for AWS Lambda to the download page and some descriptions to the FAQ section.