### PR TITLE
Fix SVG images not considered as media files

### DIFF
--- a/src/lib/loadsettings.cc
+++ b/src/lib/loadsettings.cc
@@ -32,6 +32,7 @@ namespace settings {
 QList<QString> LoadPage::mediaFilesExtensions = QList<QString> ()
 		<< "css"
 		<< "js"
+		<< "svg"
 		<< "png"
 		<< "jpg"
 		<< "jpeg"


### PR DESCRIPTION
This PR fixes the behavior of `--load-media-error-handling ignore` when SVG images fail to load.