### PR TITLE
Correct "Qt"'s capitalization.

### DIFF
--- a/CHANGELOG-OLD
+++ b/CHANGELOG-OLD
@@ -47,7 +47,7 @@ v0.10.0 beta4:
 * Command line layout reworked
 * Allow for options to be parsed on a per page section
 * Table of content is now generated via XSLT
-* Updated to use QT 4.7
+* Updated to use Qt 4.7
 * Mac binary no longer displayes in dock.
 * #72: the font spacing issues on linux solved when using --use-xserver
 * #55: wkhtmltopdf dies on unavaliable url or network disconnection
@@ -227,12 +227,12 @@ v0.6
 v0.5
 * Added support for reading command line options from stdin, to do multiple conversions fast.
 * Added options to set page margins.
-* Now shipping a binary statically compiled against QT4.5rc1, that shuld run as is on just about any Linux System.
+* Now shipping a binary statically compiled against Qt4.5rc1, that shuld run as is on just about any Linux System.
 
 v0.4
 * Added support for generation deb packages
 * Added option for dpi, low resolution and grayscale
-* Added (untested) support for removing background image when running under QT 4.5
+* Added (untested) support for removing background image when running under Qt 4.5
 
 v0.3
 * Added support for printing sites with self signed certificates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@ v0.12.2 (2015-01-09)
 
 v0.12.1 (2014-06-26)
 --------------------
-* removed support for PostScript output which is not supported in QT5
+* removed support for PostScript output which is not supported in Qt 5
 * use OpenSSL 1.0.1h for the Windows builds
 * **#1502**: fix spurious "exit with code 1 due to http error: 1xxx" errors
 * **#1504**: **[qt]** fix rendering issues for JPEG with XMP metadata
@@ -156,7 +156,7 @@ v0.12.0 (2014-02-06)
 * reserve heights when not using HTML header/footer
 * lots of improvements in the build system
 * lots of typos were fixed in various places
-* **[qt]** rebase patch series on QT 4.8.5 (now hosted on github)
+* **[qt]** rebase patch series on Qt 4.8.5 (now hosted on github)
 * **[qt]** fixes to get static builds working for MSVC 2010 (32/64 bit)
 * **[qt]** prevent page breaks in table rows
 * **[qt]** repeat THEAD/TFOOT when table contains page breaks

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ wkhtmltopdf and wkhtmltoimage
 -----------------------------
 
 wkhtmltopdf and wkhtmltoimage are command line tools to render HTML into PDF
-and various image formats using the QT Webkit rendering engine. These run
+and various image formats using the Qt Webkit rendering engine. These run
 entirely "headless" and do not require a display or display service.
 
 See http://wkhtmltopdf.org for updated documentation.

--- a/docs/libwkhtmltox/index.html
+++ b/docs/libwkhtmltox/index.html
@@ -68,7 +68,7 @@ $(function() {
 <div class="textblock"><p>libwkhtmltox is divided into several parts.</p>
 <h1><a class="anchor" id="PDFH"></a>
 To PDF c-bindings</h1>
-<p>The file <a class="el" href="pdf_8h.html">pdf.h</a> contains a fairly high level and stable pure c binding to wkhtmltopdf. These binding are well documented and do not depend on QT. Using this is the recommended way of interfacing with the PDF portion of libwkhtmltox.</p>
+<p>The file <a class="el" href="pdf_8h.html">pdf.h</a> contains a fairly high level and stable pure c binding to wkhtmltopdf. These bindings are well-documented and do not depend on Qt. Using this is the recommended way of interfacing with the PDF portion of libwkhtmltox.</p>
 <p>Using these binding it is relatively straight forward to convert one or more HTML document to a PDF file, using the following process:</p>
 <ul>
 <li>wkhtmltopdf_init is called.</li>
@@ -87,7 +87,7 @@ To PDF c-bindings</h1>
 </ul>
 <h1><a class="anchor" id="IMAGEH"></a>
 To image c-bindings</h1>
-<p>The file image.h contains a fairly high level and stable pure c binding to wkhtmltoimage. These binding are well documented and do not depend on QT. Using this is the recommended way of interfacing with the image portion of libwkhtmltox.</p>
+<p>The file image.h contains a fairly high level and stable pure c binding to wkhtmltoimage. These bindings are well documented and do not depend on Qt. Using this is the recommended way of interfacing with the image portion of libwkhtmltox.</p>
 <p>Using these binding it is relatively straight forward to convert one or more HTML document to a raster image or SVG document, using the following process:</p>
 <ul>
 <li>wkhtmltoimage_init is called.</li>
@@ -100,7 +100,7 @@ To image c-bindings</h1>
 </ul>
 <h1><a class="anchor" id="RESTH"></a>
 The rest of the headers.</h1>
-<p>The rest of the headers directly exposes the C++ QT dependent class used internally by wkhtmltopdf and wkhtmltoimage. They are not fairly well documented and are not guaranteed to remain stable. unless you know what you are doing you should not use these bindings. </p>
+<p>The rest of the headers directly expose the C++ Qt dependent class used internally by wkhtmltopdf and wkhtmltoimage. They are not fairly well documented and are not guaranteed to remain stable. unless you know what you are doing you should not use these bindings. </p>
 </div></div><!-- PageDoc -->
 </div><!-- contents -->
 <!-- start footer part -->

--- a/src/lib/converter.cc
+++ b/src/lib/converter.cc
@@ -49,7 +49,7 @@ void ConverterPrivate::updateWebSettings(QWebSettings * ws, const settings::Web 
 	ws->setAttribute(QWebSettings::JavascriptCanOpenWindows, false);
 	ws->setAttribute(QWebSettings::JavascriptCanAccessClipboard, false);
 	ws->setFontSize(QWebSettings::MinimumFontSize, s.minimumFontSize);
-	//Newer versions of QT have even more settings to change
+	//Newer versions of Qt have even more settings to change
 	ws->setAttribute(QWebSettings::PrintElementBackgrounds, s.background);
 	ws->setAttribute(QWebSettings::AutoLoadImages, s.loadImages);
 	ws->setAttribute(QWebSettings::PluginsEnabled, s.enablePlugins);

--- a/src/lib/doc.cc
+++ b/src/lib/doc.cc
@@ -27,7 +27,7 @@
  *
  * The file \ref pdf.h contains a
  * fairly high level and stable pure c binding to wkhtmltopdf.  These
- * binding are well documented and do not depend on QT.  Using this is
+ * bindings are well documented and do not depend on Qt.  Using this is
  * the recommended way of interfacing with the PDF portion of
  * libwkhtmltox.
  *
@@ -55,7 +55,7 @@
  *
  * The file \ref image.h contains a
  * fairly high level and stable pure c binding to wkhtmltoimage.  These
- * binding are well documented and do not depend on QT.  Using this is
+ * binding are well documented and do not depend on Qt.  Using this is
  * the recommended way of interfacing with the image portion of
  * libwkhtmltox.
  *
@@ -75,7 +75,7 @@
  *
  * \section RESTH The rest of the headers.
  *
- * The rest of the headers directly exposes the C++ QT dependent class
+ * The rest of the headers directly exposes the C++ Qt-dependent class
  * used internally by wkhtmltopdf and wkhtmltoimage. They are not
  * fairly well documented and are not guaranteed to remain stable.
  * unless you know what you are doing you should not use these bindings.

--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -436,8 +436,8 @@ void ResourceObject::amfinished(QNetworkReply * reply) {
 		bool mediaFile = settings::LoadPage::mediaFilesExtensions.contains(extension);
 		if ( ! mediaFile) {
 			// XXX: Notify network errors as higher priority than HTTP errors.
-			//      QT's QNetworkReply::NetworkError enum uses values overlapping
-			//      HTTP status codes, so adding 1000 to QT's codes will avoid
+			//      Qt's QNetworkReply::NetworkError enum uses values overlapping
+			//      HTTP status codes, so adding 1000 to Qt's codes will avoid
 			//      confusion. Also a network error at this point will probably mean
 			//      no HTTP access at all, so we want network errors to be reported
 			//      with a higher priority than HTTP ones.

--- a/src/lib/pdf_c_bindings.cc
+++ b/src/lib/pdf_c_bindings.cc
@@ -259,9 +259,9 @@ MyPdfConverter::~MyPdfConverter() {
 
 
 /**
- * \brief Check if the library is build against the wkhtmltopdf version of QT
+ * \brief Check if the library is build against the wkhtmltopdf version of Qt
  *
- * \return 1 if the library was build against the wkhtmltopdf version of QT and 0 otherwise
+ * \return 1 if the library was build against the wkhtmltopdf version of Qt and 0 otherwise
  */
 CAPI(int) wkhtmltopdf_extended_qt() {
 #ifdef __EXTENSIVE_WKHTMLTOPDF_QT_HACK__

--- a/src/lib/pdfconverter.cc
+++ b/src/lib/pdfconverter.cc
@@ -156,7 +156,7 @@ void PdfConverterPrivate::beginConvert() {
 
 #ifndef __EXTENSIVE_WKHTMLTOPDF_QT_HACK__
 	if (objects.size() > 1) {
-		emit out.error("This version of wkhtmltopdf is built against an unpatched version of QT, and does not support more than one input document.");
+		emit out.error("This version of wkhtmltopdf is built against an unpatched version of Qt, and does not support more than one input document.");
 		fail();
 		return;
 	}

--- a/src/pdf/pdfdocparts.cc
+++ b/src/pdf/pdfdocparts.cc
@@ -114,15 +114,15 @@ void PdfCommandLineParser::outputNotPatched(Outputter * o, bool sure) const {
 	o->beginSection("Reduced Functionality");
 	if (sure)
 		o->paragraph("This version of wkhtmltopdf has been compiled against a version of "
-					 "QT without the wkhtmltopdf patches. Therefore some features are missing, "
+					 "Qt without the wkhtmltopdf patches. Therefore some features are missing, "
 					 "if you need these features please use the static version.");
 	else
-		o->paragraph("Some versions of wkhtmltopdf are compiled against a version of QT "
+		o->paragraph("Some versions of wkhtmltopdf are compiled against a version of Qt "
 					 "without the wkhtmltopdf patches. These versions are missing some features, "
 					 "you can find out if your version of wkhtmltopdf is one of these by running wkhtmltopdf --version "
-					 "if your version is against an unpatched QT, you can use the static version to get all functionality.");
+					 "if your version is against an unpatched Qt, you can use the static version to get all functionality.");
 
-	o->paragraph("Currently the list of features only supported with patch QT includes:");
+	o->paragraph("Currently the list of features only supported with a patch Qt includes:");
 	o->beginList();
 	o->listItem("Printing more than one HTML document into a PDF file.");
 	o->listItem("Running without an X11 server.");
@@ -149,7 +149,7 @@ void PdfCommandLineParser::outputPageBreakDoc(Outputter * o) const {
 		"vertically shifted by half a line. Then WebKit will cut a line into to pieces "
 		"display the top half on one page. And the bottom half on another page. "
 		"It will also break image in two and so on.  If you are using the patched version of "
-		"QT you can use the CSS page-break-inside property to remedy this somewhat. "
+		"Qt you can use the CSS page-break-inside property to remedy this somewhat. "
 		"There is no easy solution to this problem, until this is solved try organizing "
 		"your HTML documents such that it contains many lines on which pages can be cut "
 		"cleanly.");

--- a/src/shared/commondocparts.cc
+++ b/src/shared/commondocparts.cc
@@ -68,7 +68,7 @@ void CommandLineParserBase::outputStaticProblems(Outputter * o) const {
 	o->beginParagraph();
 	o->text("On the wkhtmltopdf website you can download a static version of wkhtmltopdf ");
 	o->link("https://wkhtmltopdf.org/downloads.html");
-	o->text(". This static binary will work on most systems and comes with a build in patched QT.");
+	o->text(". This static binary will work on most systems and comes with a built-in patched Qt.");
 	o->endParagraph();
 
 	o->beginParagraph();

--- a/src/shared/htmloutputter.cc
+++ b/src/shared/htmloutputter.cc
@@ -122,7 +122,7 @@ public:
 
 	void endSwitch() {
 		fprintf(fd, "</table>\n");
-		fprintf(fd, "<p>Items marked <span style=\"font-weight: normal; font-size: 80%%; color:red;\">*</span> are only available using patched QT.</p>");
+		fprintf(fd, "<p>Items marked <span style=\"font-weight: normal; font-size: 80%%; color:red;\">*</span> are only available using a patched Qt.</p>");
 	}
 
 };

--- a/src/shared/textoutputter.cc
+++ b/src/shared/textoutputter.cc
@@ -167,7 +167,7 @@ public:
 
 	void endSwitch() {
 		if (doc)
-			fprintf(fd, "\nItems marked * are only available using patched QT.\n");
+			fprintf(fd, "\nItems marked * are only available using a patched Qt.\n");
 		printf("\n");
 	}
 


### PR DESCRIPTION
"QT" is https://en.wikipedia.org/wiki/QuickTime .

Correct some other grammar.

I hereby place my changes under CC0:

https://github.com/shlomif/shlomif-computer-settings/blob/34cab2c6dd5a0a1a1fd34ed8fbb558e65e1abc0d/shlomif-settings/git/commit-messages/cc0-copyright-disclaimer.txt

[ Untested! ]