### PR TITLE
ignore network errors according to --load-error-handling param

### DIFF
--- a/src/lib/multipageloader.cc
+++ b/src/lib/multipageloader.cc
@@ -435,16 +435,15 @@ void ResourceObject::amfinished(QNetworkReply * reply) {
 		QString extension = fi.completeSuffix().toLower().remove(QRegExp("\\?.*$"));
 		bool mediaFile = settings::LoadPage::mediaFilesExtensions.contains(extension);
 		if ( ! mediaFile) {
-			// XXX: Notify network errors as higher priority than HTTP errors.
-			//      QT's QNetworkReply::NetworkError enum uses values overlapping
-			//      HTTP status codes, so adding 1000 to QT's codes will avoid
-			//      confusion. Also a network error at this point will probably mean
-			//      no HTTP access at all, so we want network errors to be reported
-			//      with a higher priority than HTTP ones.
-			//      See: http://doc-snapshot.qt-project.org/4.8/qnetworkreply.html#NetworkError-enum
-			error(QString("Failed to load %1, with network status code %2 and http status code %3 - %4")
-				.arg(reply->url().toString()).arg(networkStatus).arg(httpStatus).arg(reply->errorString()));
-			httpErrorCode = networkStatus > 0 ? (networkStatus + 1000) : httpStatus;
+			if (settings.loadErrorHandling == settings::LoadPage::abort) {
+				error(QString("Failed to load %1, with network status code %2 and http status code %3 - %4")
+					.arg(reply->url().toString()).arg(networkStatus).arg(httpStatus).arg(reply->errorString()));
+			}
+			else {
+				warning(QString("Failed to load %1, with network status code %2 and http status code %3 - %4 (%5)")
+					.arg(reply->url().toString()).arg(networkStatus).arg(httpStatus).arg(reply->errorString())
+					.arg(settings.loadErrorHandling));
+			}
 			return;
 		}
 		if (settings.mediaLoadErrorHandling == settings::LoadPage::abort)


### PR DESCRIPTION
piggy-backing on https://github.com/wkhtmltopdf/wkhtmltopdf/pull/4461

I am trying to generate PDFs of user-submitted HTML documents, some of these try to load invalid fonts.

As of today, using `--load-error-handling ignore` still leads to `Exit with code 1 due to network error: UnknownContentError` -> that's not what I expected.

I've taken into account the suggestion on #4461 and taken the opportunity to remove an unreachable line of code and its comment. Let me know if that's OK. 🦍 